### PR TITLE
comment out majority of complexity in publish

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,159 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug executable 'rye'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=rye",
+                    "--package=rye"
+                ],
+                "filter": {
+                    "name": "rye",
+                    "kind": "bin"
+                }
+            },
+            "args": ["publish", "--repository", "toolsense-py-utils"],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in executable 'rye'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bin=rye",
+                    "--package=rye"
+                ],
+                "filter": {
+                    "name": "rye",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'test_add'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=test_add",
+                    "--package=rye"
+                ],
+                "filter": {
+                    "name": "test_add",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'test_config'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=test_config",
+                    "--package=rye"
+                ],
+                "filter": {
+                    "name": "test_config",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'test_ruff'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=test_ruff",
+                    "--package=rye"
+                ],
+                "filter": {
+                    "name": "test_ruff",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'test_self'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=test_self",
+                    "--package=rye"
+                ],
+                "filter": {
+                    "name": "test_self",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'test_sync'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=test_sync",
+                    "--package=rye"
+                ],
+                "filter": {
+                    "name": "test_sync",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'test_tools'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=test_tools",
+                    "--package=rye"
+                ],
+                "filter": {
+                    "name": "test_tools",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "rye"
-version = "0.26.0"
+version = "0.26.1-alpha"
 dependencies = [
  "age",
  "anyhow",

--- a/rye/Cargo.toml
+++ b/rye/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rye"
-version = "0.26.0"
+version = "0.26.1-alpha"
 edition = "2021"
 license = "MIT"
 

--- a/rye/src/cli/publish.rs
+++ b/rye/src/cli/publish.rs
@@ -65,108 +65,111 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
     // Get the files to publish.
     let files = match cmd.dist {
         Some(paths) => paths,
-        None => vec![project.workspace_path().join("dist").join("*")],
+        None => vec![project.workspace_path().join("dist/*")],
     };
 
     // a. Get token from arguments and offer encryption, then store in credentials file.
     // b. Get token from ~/.rye/credentials keyed by provided repository and provide decryption option.
     // c. Otherwise prompt for token and provide encryption option, storing the result in credentials.
     let repository = &cmd.repository;
-    let mut credentials = get_credentials()?;
-    credentials
-        .entry(repository)
-        .or_insert(Item::Table(Table::new()));
+    // let mut credentials = get_credentials()?;
+    // credentials
+    //     .entry(repository)
+    //     .or_insert(Item::Table(Table::new()));
 
-    let repository_url = match cmd.repository_url {
-        Some(url) => url,
-        None => {
-            let default_repository_url = Url::parse("https://upload.pypi.org/legacy/")?;
-            credentials
-                .get(repository)
-                .and_then(|table| table.get("repository-url"))
-                .map(|url| match Url::parse(&escape_string(url.to_string())) {
-                    Ok(url) => url,
-                    Err(_) => default_repository_url.clone(),
-                })
-                .unwrap_or(default_repository_url)
-        }
-    };
+    // let repository_url = match cmd.repository_url {
+    //     Some(url) => url,
+    //     None => {
+    //         let default_repository_url = Url::parse("https://upload.pypi.org/legacy/")?;
+    //         credentials
+    //             .get(repository)
+    //             .and_then(|table| table.get("repository-url"))
+    //             .map(|url| match Url::parse(&escape_string(url.to_string())) {
+    //                 Ok(url) => url,
+    //                 Err(_) => default_repository_url.clone(),
+    //             })
+    //             .unwrap_or(default_repository_url)
+    //     }
+    // };
 
     // If -r is pypi but the url isn't pypi then bail
-    if repository == "pypi" && repository_url.domain() != Some("upload.pypi.org") {
-        bail!("invalid pypi url {} (use -h for help)", repository_url);
-    }
+    // if repository == "pypi" && repository_url.domain() != Some("upload.pypi.org") {
+    //     bail!("invalid pypi url {} (use -h for help)", repository_url);
+    // }
 
-    let username = match cmd.username {
-        Some(username) => username,
-        None => credentials
-            .get(repository)
-            .and_then(|table| table.get("username"))
-            .map(|username| username.to_string())
-            .map(escape_string)
-            .unwrap_or("__token__".to_string()),
-    };
+    // let username = match cmd.username {
+    //     Some(username) => username,
+    //     None => credentials
+    //         .get(repository)
+    //         .and_then(|table| table.get("username"))
+    //         .map(|username| username.to_string())
+    //         .map(escape_string)
+    //         .unwrap_or("__token__".to_string()),
+    // };
 
-    let token = if let Some(token) = cmd.token {
-        let secret = Secret::new(token);
-        let maybe_encrypted = maybe_encrypt(&secret, cmd.yes)?;
-        let maybe_encoded = maybe_encode(&secret, &maybe_encrypted);
-        credentials[repository]["token"] = Item::Value(maybe_encoded.expose_secret().into());
-        write_credentials(&credentials)?;
+    // let token = if let Some(token) = cmd.token {
+    //     let secret = Secret::new(token);
+    //     let maybe_encrypted = maybe_encrypt(&secret, cmd.yes)?;
+    //     let maybe_encoded = maybe_encode(&secret, &maybe_encrypted);
+    //     credentials[repository]["token"] = Item::Value(maybe_encoded.expose_secret().into());
+    //     write_credentials(&credentials)?;
 
-        secret
-    } else if let Some(token) = credentials
-        .get(repository)
-        .and_then(|table| table.get("token"))
-        .map(|token| token.to_string())
-        .map(escape_string)
-    {
-        let secret = Secret::new(token);
+    //     secret
+    // } else if let Some(token) = credentials
+    //     .get(repository)
+    //     .and_then(|table| table.get("token"))
+    //     .map(|token| token.to_string())
+    //     .map(escape_string)
+    // {
+    //     let secret = Secret::new(token);
 
-        maybe_decrypt(&secret, cmd.yes)?
-    } else {
-        echo!("No access token found, generate one at: https://pypi.org/manage/account/token/");
-        let token = if !cmd.yes {
-            prompt_for_token()?
-        } else {
-            "".to_string()
-        };
-        if token.is_empty() {
-            bail!("an access token is required")
-        }
-        let secret = Secret::new(token);
-        let maybe_encrypted = maybe_encrypt(&secret, cmd.yes)?;
-        let maybe_encoded = maybe_encode(&secret, &maybe_encrypted);
-        credentials[repository]["token"] = Item::Value(maybe_encoded.expose_secret().into());
+    //     maybe_decrypt(&secret, cmd.yes)?
+    // } else {
+    //     echo!("No access token found, generate one at: https://pypi.org/manage/account/token/");
+    //     let token = if !cmd.yes {
+    //         prompt_for_token()?
+    //     } else {
+    //         "".to_string()
+    //     };
+    //     if token.is_empty() {
+    //         bail!("an access token is required")
+    //     }
+    //     let secret = Secret::new(token);
+    //     let maybe_encrypted = maybe_encrypt(&secret, cmd.yes)?;
+    //     let maybe_encoded = maybe_encode(&secret, &maybe_encrypted);
+    //     credentials[repository]["token"] = Item::Value(maybe_encoded.expose_secret().into());
 
-        secret
-    };
+    //     secret
+    // };
 
-    credentials[repository]["repository-url"] = Item::Value(repository_url.to_string().into());
-    credentials[repository]["username"] = Item::Value(username.clone().into());
-    write_credentials(&credentials)?;
+    // credentials[repository]["repository-url"] = Item::Value(repository_url.to_string().into());
+    // credentials[repository]["username"] = Item::Value(username.clone().into());
+    // write_credentials(&credentials)?;
 
     let mut publish_cmd = Command::new(get_venv_python_bin(&venv));
     publish_cmd
         .arg("-mtwine")
         .arg("--no-color")
         .arg("upload")
-        .args(files)
-        .arg("--username")
-        .arg(username)
-        .arg("--password")
-        .arg(token.expose_secret())
-        .arg("--repository-url")
-        .arg(repository_url.to_string());
-    if cmd.sign {
-        publish_cmd.arg("--sign");
-    }
-    if let Some(identity) = cmd.identity {
-        publish_cmd.arg("--identity").arg(identity);
-    }
-    if let Some(cert) = cmd.cert {
-        publish_cmd.arg("--cert").arg(cert);
-    }
+        // .arg("--username")
+        // .arg(username)
+        // .arg("--password")
+        // .arg(token.expose_secret())
+        // .arg("--repository-url")
+        // .arg(repository_url.to_string())
+        .arg("--repository")
+        .arg(repository)
+        .args(files);
+
+    // if cmd.sign {
+    //     publish_cmd.arg("--sign");
+    // }
+    // if let Some(identity) = cmd.identity {
+    //     publish_cmd.arg("--identity").arg(identity);
+    // }
+    // if let Some(cert) = cmd.cert {
+    //     publish_cmd.arg("--cert").arg(cert);
+    // }
 
     if output == CommandOutput::Quiet {
         publish_cmd.stdout(Stdio::null());


### PR DESCRIPTION
The publish function only seems to work for publishing package on [pypi.org](https://pypi.org) or [test.pypi.org](https://test.pypi.org/) and as I'm working primarily with a private company repository this was not ideal. Even though I used Rye for managing the whole project, I had to use Twine in a separate flow to publish the package.

After some initial discussions it turned out that Rye is using twine internally to publish packages, and there were thus no real reason why it was not working. After digging into it, the publish command basically wraps Twine, but it also adds a lot of fairly complicated checks and the parameters given to Twine was hard-coded to be a specific set of arguments adapted to publishing on pypi.org.

Commenting out the absolute majority of the additional command parsing made it work almost directly.

I just need to figure out what the rest of the commented code does and if we can remove it or if we have to adapt it.