### PR TITLE
Fall back to Twine's keyring support in publish command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ _Unreleased_
 
 <!-- released start -->
 
+- `publish` will fall back to dispatching username and repository url for Twine's keyring support. #759
+
+- `publish` now includes `--skip-save-credentials`. #759
+
 ## 0.32.0
 
 Released on 2024-03-29

--- a/docs/guide/commands/publish.md
+++ b/docs/guide/commands/publish.md
@@ -26,7 +26,7 @@ $ rye publish dist/example-0.1.0.tar.gz
 
 ## Options
 
-* `-r, --repository <REPOSITORY>`: The repository to publish to [default: `pypi`]
+* `-r, --repository <REPOSITORY>`: The repository to publish to
 
 * `--repository-url <REPOSITORY_URL>`: The repository url to publish to
 

--- a/docs/guide/commands/publish.md
+++ b/docs/guide/commands/publish.md
@@ -42,6 +42,8 @@ $ rye publish dist/example-0.1.0.tar.gz
 
 * `--skip-existing`: Skip files already published (repository must support this feature)
 
+* `--skip-save-credentials`: Skip saving to credentials file
+
 * `-y, --yes`: Skip prompts
 
 * `-v, --verbose`: Enables verbose diagnostics

--- a/docs/guide/publish.md
+++ b/docs/guide/publish.md
@@ -65,3 +65,19 @@ Rye will store your repository info in `$HOME/.rye/credentials` for future use.
 ### --skip-existing
 
 You can use `--skip-existing` to skip any distribution files that have already been published to the repository. Note that some repositories may not support this feature.
+
+### Using Keyring
+
+Rye will attempt to fall back to Keyring if it could not resolve enough credentials. Since Rye offers token management it will prioritize that system. So if `-y` is not passed to skip its prompts, Rye will still prompt you for credentials without checking for Keyring backends.
+
+By default Rye targets PyPI. So if you have your PyPI authentication configured to use Keyring, you can skip Rye's prompts and it will try to fall back to Keyring.
+
+```
+rye publish -y
+```
+
+If you're using another repository you can also pass `--repository-url` and `--username` to use that Keyring setup.
+
+```
+rye publish --username <username> --repository-url <url> -y
+```

--- a/docs/guide/publish.md
+++ b/docs/guide/publish.md
@@ -66,6 +66,10 @@ Rye will store your repository info in `$HOME/.rye/credentials` for future use.
 
 You can use `--skip-existing` to skip any distribution files that have already been published to the repository. Note that some repositories may not support this feature.
 
+### --skip-save-credentials
+
+Since Rye offers credentials management this data is stored in its credentials file. You can skip this step by passing `--skip-save-credentials`.
+
 ### Using Keyring
 
 Rye will attempt to fall back to Keyring if it could not resolve enough credentials. Since Rye offers token management it will prioritize that system. So if `-y` is not passed to skip its prompts, Rye will still prompt you for credentials without checking for Keyring backends.

--- a/rye/src/cli/publish.rs
+++ b/rye/src/cli/publish.rs
@@ -27,8 +27,8 @@ pub struct Args {
     /// The distribution files to upload to the repository (defaults to <workspace-root>/dist/*).
     dist: Option<Vec<PathBuf>>,
     /// The repository to publish to.
-    #[arg(short, long, default_value = "pypi")]
-    repository: String,
+    #[arg(short, long)]
+    repository: Option<String>,
     /// The repository url to publish to.
     #[arg(long)]
     repository_url: Option<Url>,
@@ -50,6 +50,9 @@ pub struct Args {
     /// Skip files that have already been published (only applies to repositories supporting this feature)
     #[arg(long)]
     skip_existing: bool,
+    /// Skip saving to credentials file.
+    #[arg(long)]
+    skip_save_credentials: bool,
     /// Skip prompts.
     #[arg(short, long)]
     yes: bool,

--- a/rye/src/cli/publish.rs
+++ b/rye/src/cli/publish.rs
@@ -119,12 +119,12 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
             }
             credentials.password = prompt_token()?;
             should_encrypt = credentials.password.is_some();
+        }
 
-            if should_encrypt {
-                passphrase = prompt_encrypt_passphrase()?;
-            } else if should_decrypt {
-                passphrase = prompt_decrypt_passphrase()?;
-            }
+        if should_encrypt {
+            passphrase = prompt_encrypt_passphrase()?;
+        } else if should_decrypt {
+            passphrase = prompt_decrypt_passphrase()?;
         }
 
         if repository.url.is_none() {

--- a/rye/src/cli/publish.rs
+++ b/rye/src/cli/publish.rs
@@ -16,6 +16,11 @@ use crate::platform::{get_credentials, write_credentials};
 use crate::pyproject::PyProject;
 use crate::utils::{escape_string, get_venv_python_bin, tui_theme, CommandOutput};
 
+const DEFAULT_USERNAME: &str = "__token__";
+const DEFAULT_REPOSITORY: &str = "pypi";
+const DEFAULT_REPOSITORY_DOMAIN: &str = "upload.pypi.org";
+const DEFAULT_REPOSITORY_URL: &str = "https://upload.pypi.org/legacy/";
+
 /// Publish packages to a package repository.
 #[derive(Parser, Debug)]
 pub struct Args {

--- a/rye/src/cli/publish.rs
+++ b/rye/src/cli/publish.rs
@@ -539,20 +539,6 @@ fn get_trimmed_user_input() -> Result<String, Error> {
     Ok(input.trim().to_string())
 }
 
-/// Helper function to manage potentially encoding secret data.
-///
-/// If the original secret data (bytes) are not the same as the new secret's
-/// then we encode, assuming the new data is encrypted data. Otherwise return
-/// a new secret with the same string.
-fn maybe_encode(original_secret: &Secret<String>, new_secret: &Secret<Vec<u8>>) -> Secret<String> {
-    if original_secret.expose_secret().as_bytes() != new_secret.expose_secret() {
-        let encoded = hex::encode(new_secret.expose_secret());
-        return Secret::new(encoded);
-    }
-
-    original_secret.clone()
-}
-
 fn pad_hex(s: String) -> String {
     if s.len() % 2 == 1 {
         format!("0{}", s)

--- a/rye/tests/common/mod.rs
+++ b/rye/tests/common/mod.rs
@@ -61,6 +61,30 @@ toolchain = "cpython@3.12.2"
         .unwrap();
     }
 
+    // write the credentials file
+    let credentials_file = home.join("credentials");
+    if !credentials_file.is_file() {
+        fs::write(
+            credentials_file,
+            r#"
+[pypi]
+# Update pypi repository url to avoid using it during tests
+repository-url = "don't use"
+
+[found-username-token]
+username = "username"
+token = "token"
+
+[found-token]
+token = "token"
+
+[found-username]
+username = "username"
+"#,
+        )
+        .unwrap();
+    }
+
     // fetch the most important interpreters.  Fetch some with and some without
     // build info to make sure we cover our grounds here.
     for (version, build_info) in [
@@ -117,6 +141,7 @@ pub fn get_bin() -> PathBuf {
     get_cargo_bin("rye")
 }
 
+#[derive(Debug)]
 pub struct Space {
     #[allow(unused)]
     tempdir: TempDir,

--- a/rye/tests/test_publish.rs
+++ b/rye/tests/test_publish.rs
@@ -1,4 +1,5 @@
 use crate::common::{rye_cmd_snapshot, Space};
+use insta_cmd::Command;
 
 mod common;
 
@@ -26,6 +27,145 @@ fn test_publish_outside_project() {
     ----- stdout -----
 
     ----- stderr -----
-    error: failed to publish files
+    error: relative URL without a base
     "###);
+}
+
+#[test]
+fn test_publish_yes() {
+    let space = Space::new();
+    space.init("my-project");
+
+    rye_cmd_snapshot!(with_skip_save(space.rye_cmd().arg("publish").arg("-y")), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    error: relative URL without a base
+    "###);
+}
+
+#[test]
+fn test_publish_from_credentials_missing_repo() {
+    let space = Space::new();
+    space.init("my-project");
+
+    rye_cmd_snapshot!(with_skip_save(space.rye_cmd().arg("publish").arg("-r").arg("missing")), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    Access token: Repository URL: error: failed to resolve configuration for repository 'missing'
+    "###);
+}
+
+#[test]
+fn test_publish_from_credentials_missing_repo_yes() {
+    let space = Space::new();
+    space.init("my-project");
+
+    rye_cmd_snapshot!(with_skip_save(space.rye_cmd().arg("publish").arg("-r").arg("missing").arg("-y")), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    error: failed to resolve configuration for repository 'missing'
+    "###);
+}
+
+#[test]
+fn test_publish_from_credentials_found_repo_with_username() {
+    let space = Space::new();
+    space.init("my-project");
+
+    rye_cmd_snapshot!(with_skip_save(space.rye_cmd().arg("publish").arg("-r").arg("found-username")), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    Access token: Repository URL: error: failed to resolve configuration for repository 'found-username'
+    "###);
+}
+
+#[test]
+fn test_publish_from_credentials_found_repo_with_token() {
+    let space = Space::new();
+    space.init("my-project");
+
+    rye_cmd_snapshot!(with_skip_save(space.rye_cmd().arg("publish").arg("-r").arg("found-token")), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    Repository URL: error: failed to resolve configuration for repository 'found-token'
+    "###);
+}
+
+#[test]
+fn test_publish_from_credentials_found_repo_with_username_token() {
+    let space = Space::new();
+    space.init("my-project");
+
+    rye_cmd_snapshot!(with_skip_save(space.rye_cmd().arg("publish").arg("-r").arg("found-username-token")), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    Repository URL: error: failed to resolve configuration for repository 'found-username-token'
+    "###);
+}
+
+#[test]
+fn test_publish_from_credentials_found_repo_with_username_yes() {
+    let space = Space::new();
+    space.init("my-project");
+
+    rye_cmd_snapshot!(with_skip_save(space.rye_cmd().arg("publish").arg("-r").arg("found-username")).arg("-y"), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    error: failed to resolve configuration for repository 'found-username'
+    "###);
+}
+
+#[test]
+fn test_publish_from_credentials_found_repo_with_token_yes() {
+    let space = Space::new();
+    space.init("my-project");
+
+    rye_cmd_snapshot!(with_skip_save(space.rye_cmd().arg("publish").arg("-r").arg("found-token")).arg("-y"), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    error: failed to resolve configuration for repository 'found-token'
+    "###);
+}
+
+#[test]
+fn test_publish_from_credentials_found_repo_with_username_token_yes() {
+    let space = Space::new();
+    space.init("my-project");
+
+    rye_cmd_snapshot!(with_skip_save(space.rye_cmd().arg("publish").arg("-r").arg("found-username-token")).arg("-y"), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    error: failed to resolve configuration for repository 'found-username-token'
+    "###);
+}
+
+fn with_skip_save(cmd: &mut Command) -> &mut Command {
+    cmd.arg("--skip-save-credentials")
 }

--- a/rye/tests/test_publish.rs
+++ b/rye/tests/test_publish.rs
@@ -102,7 +102,10 @@ fn test_publish_from_credentials_found_repo_with_token() {
     ----- stdout -----
 
     ----- stderr -----
-    Repository URL: error: failed to resolve configuration for repository 'found-token'
+    error: IO error: not a terminal
+
+    Caused by:
+        not a terminal
     "###);
 }
 
@@ -117,7 +120,10 @@ fn test_publish_from_credentials_found_repo_with_username_token() {
     ----- stdout -----
 
     ----- stderr -----
-    Repository URL: error: failed to resolve configuration for repository 'found-username-token'
+    error: IO error: not a terminal
+
+    Caused by:
+        not a terminal
     "###);
 }
 


### PR DESCRIPTION
From #741, Rye is unable to publish packages with Twine if users rely on keyring.

I'm not sure if the plan is to implement more of the publish logic ourselves. In case it's not or we're still far off from that, this PR offers a fix for #741 by updating the publish command logic to fall back to Twine's keyring support.

Changes:
- Dynamic dispatch of `--username`, `--token`, and `--repository-url` to allow keyring fallback.
- `--skip-save-credentials` to prevent potential confusing behavior and provide users with an opt-out method.
- Refactored  the credentials resolution, prompting, and save credentials code

Testing:

* Publish configuration resolution tests
* Snapshots
* Manual (see below)

Manual testing:

```
testpypi-package on  main [?] is 📦 v0.4.0 via 🐍 took 34s 
❯ cat ~/.rye/credentials
[pypi]
token = <token>
username = "__token__"
repository-url = "https://upload.pypi.org/legacy/"

testpypi-package on  main [?] is 📦 v0.4.0 via 🐍 
❯ rye publish -r 'testpypi'
Access token: <token>
Repository URL: https://test.pypi.org/legacy/
Uploading distributions to https://test.pypi.org/legacy/
Uploading testpypi_package-0.4.0-py3-none-any.whl
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.3/4.3 kB • 00:00 • ?
Uploading testpypi_package-0.4.0.tar.gz
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.9/3.9 kB • 00:00 • ?

View at:
https://test.pypi.org/project/testpypi-package/0.4.0/

testpypi-package on  main [?] is 📦 v0.4.0 via 🐍 took 6s 
❯ rye publish -r 'testpypi'
? Decrypt with passphrase (optional) › 

testpypi-package on  main [?] is 📦 v0.4.0 via 🐍 
❯ rye publish -r 'testpypi' --token <token>
? Encrypt with passphrase (optional) › 

testpypi-package on  main [?] is 📦 v0.4.0 via 🐍 
❯ cat ~/.rye/credentials 
[pypi]
repository-url = "https://upload.pypi.org/legacy/"

[testpypi]
username = "__token__"
repository-url = "https://test.pypi.org/legacy/"
```

<img width="1425" alt="image" src="https://github.com/astral-sh/rye/assets/14341145/6c6e07db-2a07-4f76-9848-a5695610c535">

Edit: Cleaned up the description for latest changes.