### PR TITLE
Rename rye-test-home to rye-test-dir

### DIFF
--- a/rye/tests/common/mod.rs
+++ b/rye/tests/common/mod.rs
@@ -17,7 +17,10 @@ pub const INSTA_FILTERS: &[(&str, &str)] = &[
         "[TEMP_PATH]/",
     ),
     // home
-    (r"(\b[A-Z]:)?[\\/].*?[\\/]home", "[RYE_HOME]"),
+    (
+        r"(\b[A-Z]:)?[\\/].*?[\\/]rye-test-dir[\\/]home",
+        "[RYE_HOME]",
+    ),
     // macos temp folder
     (r"/var/folders/\S+?/T/\S+", "[TEMP_FILE]"),
     // linux temp folders

--- a/rye/tests/common/mod.rs
+++ b/rye/tests/common/mod.rs
@@ -17,7 +17,7 @@ pub const INSTA_FILTERS: &[(&str, &str)] = &[
         "[TEMP_PATH]/",
     ),
     // home
-    (r"(\b[A-Z]:)?[\\/].*?[\\/]rye-test-home", "[RYE_HOME]"),
+    (r"(\b[A-Z]:)?[\\/].*?[\\/]home", "[RYE_HOME]"),
     // macos temp folder
     (r"/var/folders/\S+?/T/\S+", "[TEMP_FILE]"),
     // linux temp folders
@@ -34,7 +34,9 @@ fn marked_tempdir() -> TempDir {
 }
 
 fn bootstrap_test_rye() -> PathBuf {
-    let home = get_bin().parent().unwrap().join("rye-test-home");
+    let test_dir = get_bin().parent().unwrap().join("rye-test-dir");
+    let home = test_dir.join("home");
+
     fs::create_dir_all(&home).ok();
     let lock_path = home.join("lock");
     let mut lock = fslock::LockFile::open(&lock_path).unwrap();


### PR DESCRIPTION
In #759 I'd like to add a wheels directory as part of the testing resources we're storing in target/debug/rye-test-home.

I've changed RYE_HOME to rye-test-dir/home. I'd add rye-test-dir/wheels in #759.