### PR TITLE
Use 'cargo insta test' in Makefile's test command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,10 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@v2
+      - name: Install cargo insta
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-insta
       - name: Check
         run: make check
       - name: Test
@@ -28,6 +32,10 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@v2
+      - name: Install cargo insta
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-insta
       - name: Check
         run: make check
       - name: Test
@@ -43,6 +51,10 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@v2
+      - name: Install cargo insta
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-insta
       - name: Check
         run: make check
       - name: Test

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build:
 
 .PHONY: test
 test:
-	@cargo test --all
+	@cargo insta test --workspace --all-features
 
 .PHONY: check
 check:


### PR DESCRIPTION
I'm sure it's intentional to not run everything in CI. I felt it might be helpful especially for the CLI to fully run.