### PR TITLE
Add `rye fetch --force` to re-fetch a toolchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ _Unreleased_
 
 - When `uv` is used the prompt is now set to the project name.  #773
 
-- Allow `rye fetch --force` to force re-fetch a downloaded toolchain.  #xxx
+- Allow `rye fetch --force` to force re-fetch a downloaded toolchain.  #778
 
 <!-- released start -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ _Unreleased_
 
 - When `uv` is used the prompt is now set to the project name.  #773
 
+- Allow `rye fetch --force` to force re-fetch a downloaded toolchain.  #xxx
+
 <!-- released start -->
 
 ## 0.26.0

--- a/docs/guide/commands/fetch.md
+++ b/docs/guide/commands/fetch.md
@@ -11,7 +11,8 @@ Fetch a specific version of Python:
 $ rye fetch 3.8.13
 Downloading cpython@3.8.13
 Checking checksum
-success: Downloaded cpython@3.8.13
+Unpacking
+Downloaded cpython@3.8.13
 ```
 
 To fetch the pinned version of Python you can leave out the argument:
@@ -20,7 +21,8 @@ To fetch the pinned version of Python you can leave out the argument:
 $ rye fetch
 Downloading cpython@3.8.17
 Checking checksum
-success: Downloaded cpython@3.8.17
+Unpacking
+Downloaded cpython@3.8.17
 ```
 
 ## Arguments

--- a/docs/guide/commands/fetch.md
+++ b/docs/guide/commands/fetch.md
@@ -31,6 +31,8 @@ success: Downloaded cpython@3.8.17
 
 ## Options
 
+* `-f, --force`: Fetch the Python toolchain even if it is already installed.
+
 * `-v, --verbose`: Enables verbose diagnostics
 
 * `-q, --quiet`: Turns off all output

--- a/rye/src/cli/fetch.rs
+++ b/rye/src/cli/fetch.rs
@@ -15,6 +15,9 @@ pub struct Args {
     ///
     /// If no version is provided, the requested version from local project or `.python-version` will be fetched.
     version: Option<String>,
+    /// Fetch the Python toolchain even if it is already installed.
+    #[arg(short, long)]
+    force: bool,
     /// Enables verbose diagnostics.
     #[arg(short, long)]
     verbose: bool,
@@ -40,6 +43,6 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
         }
     };
 
-    fetch(&version, output).context("error while fetching Python installation")?;
+    fetch(&version, output, cmd.force).context("error while fetching Python installation")?;
     Ok(())
 }

--- a/rye/src/installer.rs
+++ b/rye/src/installer.rs
@@ -131,7 +131,7 @@ pub fn install(
     uninstall_helper(&target_venv_path, &shim_dir)?;
 
     // make sure we have a compatible python version
-    let py_ver = fetch(py_ver, output)?;
+    let py_ver = fetch(py_ver, output, false)?;
 
     create_virtualenv(
         output,

--- a/rye/src/sync.rs
+++ b/rye/src/sync.rs
@@ -147,7 +147,7 @@ pub fn sync(mut cmd: SyncOptions) -> Result<(), Error> {
 
     // make sure we have a compatible python version
     let py_ver =
-        fetch(&py_ver.into(), output).context("failed fetching toolchain ahead of sync")?;
+        fetch(&py_ver.into(), output, false).context("failed fetching toolchain ahead of sync")?;
 
     // kill the virtualenv if it's there and we need to get rid of it.
     if recreate && venv.is_dir() {

--- a/rye/tests/test_toolchain.rs
+++ b/rye/tests/test_toolchain.rs
@@ -5,7 +5,8 @@ mod common;
 #[test]
 fn test_fetch() {
     let space = Space::new();
-    let version = "cpython@3.12.2";
+    // Use a version not in use by other tests and will be supported for a long time.
+    let version = "cpython@3.12.1";
 
     // Make sure the version is installed.
     let status = space.rye_cmd().arg("fetch").arg(version).status().unwrap();
@@ -27,10 +28,10 @@ fn test_fetch() {
     exit_code: 0
     ----- stdout -----
     Removing the existing Python version
-    Downloading cpython@3.12.2
+    Downloading cpython@3.12.1
     Checking checksum
     Unpacking
-    Downloaded cpython@3.12.2
+    Downloaded cpython@3.12.1
 
     ----- stderr -----
     "###);

--- a/rye/tests/test_toolchain.rs
+++ b/rye/tests/test_toolchain.rs
@@ -34,16 +34,4 @@ fn test_fetch() {
 
     ----- stderr -----
     "###);
-
-    rye_cmd_snapshot!(space.rye_cmd().arg("toolchain").arg("list"), @r###"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    cpython@3.12.2 ([RYE_HOME]/py/cpython@3.12.2/install/bin/python3)
-    cpython@3.12.1 ([RYE_HOME]/py/cpython@3.12.1/install/bin/python3)
-    cpython@3.11.8 ([RYE_HOME]/py/cpython@3.11.8/install/bin/python3)
-    cpython@3.8.17 ([RYE_HOME]/py/cpython@3.8.17/install/bin/python3)
-
-    ----- stderr -----
-    "###);
 }

--- a/rye/tests/test_toolchain.rs
+++ b/rye/tests/test_toolchain.rs
@@ -1,0 +1,49 @@
+use crate::common::{rye_cmd_snapshot, Space};
+
+mod common;
+
+#[test]
+fn test_fetch() {
+    let space = Space::new();
+    let version = "cpython@3.12.2";
+
+    // Make sure the version is installed.
+    let status = space.rye_cmd().arg("fetch").arg(version).status().unwrap();
+    assert!(status.success());
+
+    // Fetching the same version again should be a no-op.
+    rye_cmd_snapshot!(space.rye_cmd().arg("fetch").arg(version).arg("--verbose"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Python version already downloaded. Skipping.
+
+    ----- stderr -----
+    "###);
+
+    // Fetching the same version again with --force should re-download it.
+    rye_cmd_snapshot!(space.rye_cmd().arg("fetch").arg(version).arg("--force"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Removing the existing Python version
+    Downloading cpython@3.12.2
+    Checking checksum
+    Unpacking
+    Downloaded cpython@3.12.2
+
+    ----- stderr -----
+    "###);
+
+    rye_cmd_snapshot!(space.rye_cmd().arg("toolchain").arg("list"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    cpython@3.12.2 ([RYE_HOME]/py/cpython@3.12.2/install/bin/python3)
+    cpython@3.12.1 ([RYE_HOME]/py/cpython@3.12.1/install/bin/python3)
+    cpython@3.11.8 ([RYE_HOME]/py/cpython@3.11.8/install/bin/python3)
+    cpython@3.8.17 ([RYE_HOME]/py/cpython@3.8.17/install/bin/python3)
+
+    ----- stderr -----
+    "###);
+}


### PR DESCRIPTION
[indygreg/python-build-standalone](https://github.com/indygreg/python-build-standalone) may recompile an existing Python version in a subsequent release; take, for instance, the [20240224 release](https://github.com/indygreg/python-build-standalone/releases/tag/20240224), which republished Python 3.10.13. As a result, the Python toolchain you've previously downloaded might not be the most current iteration. 

This pull request adds the `--force` flag to the `rye fetch` command, to make a re-fetch of a downloaded version.