### PR TITLE
docs: update script command

### DIFF
--- a/docs/guide/basics.md
+++ b/docs/guide/basics.md
@@ -165,7 +165,7 @@ The following structure will be created:
 The [`pyproject.toml`](pyproject.md) will be generated with a
 [`[project.scripts]`](pyproject.md#projectscripts) section named `hello`
 that points to the `main()` function of `__init__.py`. After you
-synchronized your changes, you can run the script with `rye run my-project`.
+synchronized your changes, you can run the script with `rye run hello`.
 
 ```shell
 rye sync


### PR DESCRIPTION
I tried generating a project with  below commands like [the documentation](https://rye-up.com/guide/basics/#executable-projects).

```shell
rye init --script my-project
cd my-project
```

However,  the next step occurs an error.

> The [pyproject.toml](https://rye-up.com/guide/pyproject/) will be generated with a [[project.scripts]](https://rye-up.com/guide/pyproject/#projectscripts) section named `hello` that points to the `main()` function of `__init__.py`. After you synchronized your changes, you can run the script with `rye run my-project`.

```shell
rye sync
rye run my-project
error: invalid or unknown script 'my-project'
```

I checked the available commands.
```shell
rye run

hello
python
python3
python3.12
```

I don't think there is a project's name command.
That's why I updated `rye run hello` syncing the last command.

```shell
rye sync
rye run hello
```