### PR TITLE
Ignore .rye folder added by github action

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,7 @@ serve-docs = "mkdocs serve"
 
 [tool.rye.workspace]
 members = ["rye-devtools"]
+
+[tool.ruff]
+# the former folder is added by the rye github action
+exclude = [".rye", ".venv"]


### PR DESCRIPTION
This fixes an issue introduced by the latest version of the rye action.