### PR TITLE
Update CI triggers

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,6 +1,10 @@
 name: Clippy
 
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/python-format.yml
+++ b/.github/workflows/python-format.yml
@@ -1,6 +1,10 @@
 name: Python format
 
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   format:

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,6 +1,10 @@
 name: Python lint
 
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -1,6 +1,10 @@
 name: Rustfmt
 
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -1,6 +1,10 @@
 name: Spelling
 
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   typos:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,10 @@
 name: Tests
 
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   test-latest-linux:


### PR DESCRIPTION
There's some redundancy in the CI currently.

<img width="805" alt="image" src="https://github.com/astral-sh/rye/assets/14341145/9abacb1b-86ad-43c3-9b22-d4d84f2592b8">


With this change it should be this on both `main` and PRs (plus manual triggers):
<img width="854" alt="image" src="https://github.com/astral-sh/rye/assets/14341145/7c302218-e6bb-4cf2-86dc-bd568f27541b">
