### PR TITLE
Bump eifinger/setup-rye from v1 to v2

### DIFF
--- a/.github/workflows/python-format.yml
+++ b/.github/workflows/python-format.yml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: eifinger/setup-rye@v1
+      - uses: eifinger/setup-rye@v2
       - name: Rye fmt
         run: rye fmt --check

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: eifinger/setup-rye@v1
+      - uses: eifinger/setup-rye@v2
       - name: Rye lint
         run: rye lint

--- a/.github/workflows/sync-python-releases.yml
+++ b/.github/workflows/sync-python-releases.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rye
-        uses: eifinger/setup-rye@v1
+        uses: eifinger/setup-rye@v2
         with:
           enable-cache: true
       - name: Sync Python Releases

--- a/.github/workflows/sync-uv-releases.yml
+++ b/.github/workflows/sync-uv-releases.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rye
-        uses: eifinger/setup-rye@v1
+        uses: eifinger/setup-rye@v2
         with:
           enable-cache: true
       - name: Sync UV Releases

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,5 +32,4 @@ serve-docs = "mkdocs serve"
 members = ["rye-devtools"]
 
 [tool.ruff]
-# the .rye folder is added by the rye github action
-exclude = [".rye", ".venv"]
+exclude = [".venv"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,3 @@ serve-docs = "mkdocs serve"
 
 [tool.rye.workspace]
 members = ["rye-devtools"]
-
-[tool.ruff]
-exclude = [".venv"]


### PR DESCRIPTION
Also remove `.rye` from ruff excludes as it is not added any more by the action

Fixes the workaround introduced in https://github.com/astral-sh/rye/pull/822