### PR TITLE
Add `--skip-existing` to publish command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ that were not yet released.
 
 _Unreleased_
 
+- `--skip-existing` is now available with Rye's `publish` command. #831
+
 - Bumped `uv` to 0.1.13.  #760, #820
 
 - Bumped `ruff` to 0.3.0.  #821

--- a/rye/src/cli/publish.rs
+++ b/rye/src/cli/publish.rs
@@ -42,6 +42,9 @@ pub struct Args {
     /// Path to alternate CA bundle.
     #[arg(long)]
     cert: Option<PathBuf>,
+    /// Continue uploading files if one already exists (only applies to repositories supporting this feature)
+    #[arg(long)]
+    skip_existing: bool,
     /// Skip prompts.
     #[arg(short, long)]
     yes: bool,
@@ -166,6 +169,9 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
     }
     if let Some(cert) = cmd.cert {
         publish_cmd.arg("--cert").arg(cert);
+    }
+    if cmd.skip_existing {
+        publish_cmd.arg("--skip-existing");
     }
 
     if output == CommandOutput::Quiet {


### PR DESCRIPTION
While working on #759 I noticed that we didn't offer support for dispatching `--skip-existing` from Twine.

```
  --skip-existing       Continue uploading files if one already exists. (Only valid when uploading to PyPI. Other
                        implementations may not support this.)
```

Edit: This PR adds `--skip-existing` to the publish command.

~~This PR adds `--force` (`-f`) which covers dispatch of `--skip-existing`. I landed on *"force"* because I felt it was more generic. `--skip-existing` to me falls under the category of *forcing behavior*. So I decided to start with something more generic to approach this feature.~~

~~I'm kind of curious in general of `--skip-existing`, since, to me (IIUC), it's effectively a swap of an already published package -- which just feels odd to be able to do.~~

I tested this manually against upload.pypi.org. I was pretty sure that test.pypi.org implemented the same rejection, but I couldn't get it to trigger.

```
xlcsv on  master [!] is 📦 v0.1.0 via 🐍 
❯ rye publish -y                
Uploading distributions to https://upload.pypi.org/legacy/
Uploading xlcsv-0.1.0-py3-none-any.whl
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 7.0/7.0 kB • 00:00 • ?
WARNING  Error during upload. Retry with the --verbose option for more details.                                                
ERROR    HTTPError: 403 Forbidden from https://upload.pypi.org/legacy/                                                         
         Invalid or non-existent authentication information. See https://pypi.org/help/#invalid-auth for more information.     
error: failed to publish files

❯ rye publish -y --skip-existing
Uploading distributions to https://upload.pypi.org/legacy/
WARNING  Skipping xlcsv-0.1.0-py3-none-any.whl because it appears to already exist                                             
WARNING  Skipping xlcsv-0.1.0.tar.gz because it appears to already exist  
```

Other than the manual testing, I've held off on adding anything since I've already added a bunch of testing in #759.