### PR TITLE
Update publish command's `--skip-existing` description

### DIFF
--- a/docs/guide/commands/publish.md
+++ b/docs/guide/commands/publish.md
@@ -40,6 +40,8 @@ $ rye publish dist/example-0.1.0.tar.gz
 
 * `--cert <CERT>`: Path to alternate CA bundle
 
+* `--skip-existing`: Skip files already published (repository must support this feature)
+
 * `-y, --yes`: Skip prompts
 
 * `-v, --verbose`: Enables verbose diagnostics

--- a/docs/guide/publish.md
+++ b/docs/guide/publish.md
@@ -61,3 +61,7 @@ rye publish --token <your_token> --yes
 ```
 
 Rye will store your repository info in `$HOME/.rye/credentials` for future use.
+
+### --skip-existing
+
+You can use `--skip-existing` to skip any distribution files that have already been published to the repository. Note that some repositories may not support this feature.

--- a/rye/src/cli/publish.rs
+++ b/rye/src/cli/publish.rs
@@ -42,7 +42,7 @@ pub struct Args {
     /// Path to alternate CA bundle.
     #[arg(long)]
     cert: Option<PathBuf>,
-    /// Continue uploading files if one already exists (only applies to repositories supporting this feature)
+    /// Skip files that have already been published (only applies to repositories supporting this feature)
     #[arg(long)]
     skip_existing: bool,
     /// Skip prompts.


### PR DESCRIPTION
This is Twine's description of this flag:

```
  --skip-existing       Continue uploading files if one already exists. (Only valid when uploading to PyPI. Other
                        implementations may not support this.)
```

I originally interpreted this as "upload the file anyway" -- which is wrong and sounded odd since being able to replace published packages probably wouldn't be great design for a package repository.

To me this wording is more clear about what this flag actually does.