### PR TITLE
Report the actual self python version

### DIFF
--- a/rye/src/cli/mod.rs
+++ b/rye/src/cli/mod.rs
@@ -29,9 +29,10 @@ mod version;
 
 use git_testament::git_testament;
 
-use crate::bootstrap::SELF_PYTHON_TARGET_VERSION;
+use crate::bootstrap::{get_self_venv_status, SELF_PYTHON_TARGET_VERSION};
 use crate::config::Config;
 use crate::platform::symlinks_supported;
+use crate::pyproject::read_venv_marker;
 
 git_testament!(TESTAMENT);
 
@@ -151,7 +152,19 @@ fn print_version() -> Result<(), Error> {
         std::env::consts::OS,
         std::env::consts::ARCH
     );
-    echo!("self-python: {}", SELF_PYTHON_TARGET_VERSION);
+
+    let self_venv_python = match get_self_venv_status() {
+        Ok(venv_dir) | Err((venv_dir, _)) => read_venv_marker(&venv_dir).map(|mark| mark.python),
+    };
+
+    if let Some(python) = self_venv_python {
+        echo!("self-python: {}", python);
+    } else {
+        echo!(
+            "self-python: not bootstrapped (target: {})",
+            SELF_PYTHON_TARGET_VERSION
+        );
+    }
     echo!("symlink support: {}", symlinks_supported());
     echo!("uv enabled: {}", Config::current().use_uv());
     Ok(())


### PR DESCRIPTION
Inspect the venv marker for the self python environment and report its version in rye --version output.

Example (installed with 3.11.7)

```
> RYE_HOME=xyz ./xyz/shims/rye --version
rye 0.28.0
commit: 0.27.0+8 (2111778b3 2024-02-28)
platform: linux (x86_64)
self-python: cpython@3.11.7
symlink support: true
uv enabled: true

> RYE_HOME=notinstalled ./xyz/shims/rye --version
rye 0.28.0
commit: 0.27.0+8 (2111778b3 2024-02-28)
platform: linux (x86_64)
self-python: not bootstrapped (target: cpython@3.12)
symlink support: true
uv enabled: false
```