### PR TITLE
Retain version/url on rye add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ _Unreleased_
 
 - Fixes a bug where `rye config` would not create the `RYE_HOME` folder if needed.  #844
 
+- `rye add` now retains version and URL for the requirements when `uv` is used.  #846
+
 <!-- released start -->
 
 ## 0.27.0

--- a/rye/src/cli/add.rs
+++ b/rye/src/cli/add.rs
@@ -485,6 +485,14 @@ fn resolve_requirements_with_uv(
         }
 
         let mut new_req: Requirement = String::from_utf8_lossy(&rv.stdout).parse()?;
+
+        // if a version or URL is already provided we just use the normalized package name but
+        // retain all old information.
+        if req.version_or_url.is_some() {
+            req.name = new_req.name;
+            continue;
+        }
+
         if let Some(ref mut version_or_url) = new_req.version_or_url {
             if let VersionOrUrl::VersionSpecifier(ref mut specs) = version_or_url {
                 *version_or_url = VersionOrUrl::VersionSpecifier(VersionSpecifiers::from_iter({

--- a/rye/tests/test_add.rs
+++ b/rye/tests/test_add.rs
@@ -11,7 +11,7 @@ fn test_add_flask() {
     let space = Space::new();
     space.init("my-project");
     // add colorama to ensure we have this as a dependency on all platforms
-    rye_cmd_snapshot!(space.rye_cmd().arg("add").arg("flask==3.0.0").arg("colorama"), @r###"
+    rye_cmd_snapshot!(space.rye_cmd().arg("add").arg("flask").arg("colorama"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -138,7 +138,7 @@ fn test_add_flask_wrong_venv_exported() {
     ----- stdout -----
     Initializing new virtualenv in [TEMP_PATH]/project/.venv
     Python version: cpython@3.12.2
-    Added flask>=3.0.0 as regular dependency
+    Added flask==3.0.0 as regular dependency
     Added colorama>=0.4.6 as regular dependency
     Reusing already existing virtualenv
     Generating production lockfile: [TEMP_PATH]/project/requirements.lock
@@ -162,4 +162,55 @@ fn test_add_flask_wrong_venv_exported() {
      + werkzeug==3.0.1
     "###);
     fs::remove_dir_all(&fake_venv).unwrap();
+}
+
+#[test]
+fn test_add_explicit_version_or_url() {
+    let space = Space::new();
+    space.init("my-project");
+    rye_cmd_snapshot!(space.rye_cmd().arg("add").arg("werkzeug==3.0.0"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Initializing new virtualenv in [TEMP_PATH]/project/.venv
+    Python version: cpython@3.12.2
+    Added werkzeug==3.0.0 as regular dependency
+    Reusing already existing virtualenv
+    Generating production lockfile: [TEMP_PATH]/project/requirements.lock
+    Generating dev lockfile: [TEMP_PATH]/project/requirements-dev.lock
+    Installing dependencies
+    Done!
+
+    ----- stderr -----
+    Built 1 editable in [EXECUTION_TIME]
+    Resolved 2 packages in [EXECUTION_TIME]
+    Downloaded 2 packages in [EXECUTION_TIME]
+    Installed 3 packages in [EXECUTION_TIME]
+     + markupsafe==2.1.3
+     + my-project==0.1.0 (from file:[TEMP_PATH]/project)
+     + werkzeug==3.0.0
+    "###);
+
+    let pip_url = "https://github.com/pypa/pip/archive/1.3.1.zip#sha1=da9234ee9982d4bbb3c72346a6de940a148ea686";
+    rye_cmd_snapshot!(space.rye_cmd().arg("add").arg("pip").arg("--url").arg(pip_url), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Added pip @ https://github.com/pypa/pip/archive/1.3.1.zip#sha1=da9234ee9982d4bbb3c72346a6de940a148ea686 as regular dependency
+    Reusing already existing virtualenv
+    Generating production lockfile: [TEMP_PATH]/project/requirements.lock
+    Generating dev lockfile: [TEMP_PATH]/project/requirements-dev.lock
+    Installing dependencies
+    Done!
+
+    ----- stderr -----
+    Built 1 editable in [EXECUTION_TIME]
+    Resolved 1 package in [EXECUTION_TIME]
+    Downloaded 1 package in [EXECUTION_TIME]
+    Uninstalled 1 package in [EXECUTION_TIME]
+    Installed 2 packages in [EXECUTION_TIME]
+     - my-project==0.1.0 (from file:[TEMP_PATH]/project)
+     + my-project==0.1.0 (from file:[TEMP_PATH]/project)
+     + pip==1.3.1 (from https://github.com/pypa/pip/archive/1.3.1.zip#sha1=da9234ee9982d4bbb3c72346a6de940a148ea686)
+    "###);
 }

--- a/rye/tests/test_add.rs
+++ b/rye/tests/test_add.rs
@@ -168,7 +168,7 @@ fn test_add_flask_wrong_venv_exported() {
 fn test_add_explicit_version_or_url() {
     let space = Space::new();
     space.init("my-project");
-    rye_cmd_snapshot!(space.rye_cmd().arg("add").arg("werkzeug==3.0.0"), @r###"
+    rye_cmd_snapshot!(space.rye_cmd().arg("add").arg("werkZeug==3.0.0"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----

--- a/rye/tests/test_sync.rs
+++ b/rye/tests/test_sync.rs
@@ -54,7 +54,7 @@ fn test_add_and_sync_no_auto_sync() {
     ----- stdout -----
     Initializing new virtualenv in [TEMP_PATH]/project/.venv
     Python version: cpython@3.12.2
-    Added flask>=3.0.0 as regular dependency
+    Added flask==3.0.0 as regular dependency
     Added colorama>=0.4.6 as regular dependency
 
     ----- stderr -----
@@ -97,7 +97,7 @@ fn test_add_autosync() {
     ----- stdout -----
     Initializing new virtualenv in [TEMP_PATH]/project/.venv
     Python version: cpython@3.12.2
-    Added flask>=3.0.0 as regular dependency
+    Added flask==3.0.0 as regular dependency
     Added colorama>=0.4.6 as regular dependency
     Reusing already existing virtualenv
     Generating production lockfile: [TEMP_PATH]/project/requirements.lock
@@ -155,7 +155,7 @@ fn test_autosync_remember() {
     success: true
     exit_code: 0
     ----- stdout -----
-    Added flask>=3.0.0 as optional (web) dependency
+    Added flask==3.0.0 as optional (web) dependency
     Added colorama>=0.4.6 as optional (web) dependency
     Reusing already existing virtualenv
     Generating production lockfile: [TEMP_PATH]/project/requirements.lock


### PR DESCRIPTION
When `uv` is used `rye add` now retains version and URL if the requirement has version or URL.

Fixes #817

Fixes #833

Fixes #800