### PR TITLE
fix: ignore workspace root when running pytest

### DIFF
--- a/rye/src/cli/test.rs
+++ b/rye/src/cli/test.rs
@@ -83,6 +83,9 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
     }
 
     for (idx, project) in projects.iter().enumerate() {
+        if project.workspace().is_some() && project.is_workspace_root() {
+            continue;
+        }
         if output != CommandOutput::Quiet {
             if idx > 0 {
                 println!();


### PR DESCRIPTION
Fixes #853 

## Description

When running within a workspace pytest will be run from the project root collecting everything in the workspace tree (including the unselected packages and package not included in the workspace).

## Open Questions

It might the interesting to have a `rye.tests-folder` attribute so we could have workspace tests.
