### PR TITLE
Trap panics and silence bad pipe errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ _Unreleased_
 
 - Updated to `uv` 0.1.6.  #850
 
+- Trap panics and silence bad pipe errors.  #862
+
 ## 0.28.0
 
 Released on 2024-03-07

--- a/rye/src/utils/mod.rs
+++ b/rye/src/utils/mod.rs
@@ -34,6 +34,7 @@ pub(crate) mod windows;
 #[cfg(unix)]
 pub(crate) mod unix;
 
+pub(crate) mod panic;
 pub(crate) mod ruff;
 pub(crate) mod toml;
 

--- a/rye/src/utils/panic.rs
+++ b/rye/src/utils/panic.rs
@@ -1,0 +1,32 @@
+use std::any::Any;
+use std::{panic, process};
+
+fn is_bad_pipe(payload: &dyn Any) -> bool {
+    payload
+        .downcast_ref::<String>()
+        .map_or(false, |x| x.contains("failed printing to stdout: "))
+}
+
+/// Registers a panic hook that hides stdout printing failures.
+pub fn set_panic_hook() {
+    let default_hook = panic::take_hook();
+    panic::set_hook(Box::new(move |info| {
+        if !is_bad_pipe(info.payload()) {
+            default_hook(info)
+        }
+    }));
+}
+
+/// Catches down panics that are caused by bad pipe errors.
+pub fn trap_bad_pipe<F: FnOnce() -> i32 + Send + Sync>(f: F) -> ! {
+    process::exit(match panic::catch_unwind(panic::AssertUnwindSafe(f)) {
+        Ok(status) => status,
+        Err(panic) => {
+            if is_bad_pipe(&panic) {
+                1
+            } else {
+                panic::resume_unwind(panic);
+            }
+        }
+    });
+}


### PR DESCRIPTION
Pretty terrible way to do this, but given that various things might write to stdout, that might be the most reliable way.

Fixes #861