### PR TITLE
Update self-venv on rye update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ _Unreleased_
 
 - Trap panics and silence bad pipe errors.  #862
 
+- Updating `rye` will now also ensure that the self-venv is updated.  Previously
+  this was deferred until the next `sync`.  #863
+
 ## 0.28.0
 
 Released on 2024-03-07

--- a/rye/src/cli/rye.rs
+++ b/rye/src/cli/rye.rs
@@ -15,7 +15,7 @@ use self_replace::self_delete_outside_path;
 use tempfile::tempdir;
 
 use crate::bootstrap::{
-    download_url, download_url_ignore_404, ensure_self_venv_with_toolchain,
+    download_url, download_url_ignore_404, ensure_self_venv, ensure_self_venv_with_toolchain,
     is_self_compatible_toolchain, update_core_shims, SELF_PYTHON_TARGET_VERSION,
 };
 use crate::cli::toolchain::register_toolchain;
@@ -272,6 +272,8 @@ fn update(args: UpdateCommand) -> Result<(), Error> {
         "Unable to perform update. This can happen because files are in use. \
          Please stop running Python interpreters and retry the update.",
     )?;
+
+    ensure_self_venv(CommandOutput::Normal).context("update failed on updating self-python")?;
 
     echo!("Updated!");
     echo!();


### PR DESCRIPTION
After update this will attempt to run `rye init` and the `python` shim in the context of that project. This under all known Rye versions should trigger a python only sync and updating of the internals.

Fixes #859