### PR TITLE
uv: move all uv commands to uv.rs

### DIFF
--- a/rye/src/bootstrap.rs
+++ b/rye/src/bootstrap.rs
@@ -18,7 +18,7 @@ use crate::platform::{
 use crate::pyproject::latest_available_python_version;
 use crate::sources::py::{get_download_url, PythonVersion, PythonVersionRequest};
 use crate::utils::{check_checksum, symlink_file, unpack_archive, CommandOutput, IoPathContext};
-use crate::uv::Uv;
+use crate::uv::UvBuilder;
 
 /// this is the target version that we want to fetch
 pub const SELF_PYTHON_TARGET_VERSION: PythonVersionRequest = PythonVersionRequest {
@@ -123,7 +123,9 @@ pub fn ensure_self_venv_with_toolchain(
     }
 
     // Ensure we have uv
-    let uv = Uv::ensure_exists(CommandOutput::Quiet)?;
+    let uv = UvBuilder::new()
+        .with_output(CommandOutput::Quiet)
+        .ensure_exists()?;
 
     let version = match toolchain_version_request {
         Some(ref version_request) => ensure_specific_self_toolchain(output, version_request)

--- a/rye/src/cli/add.rs
+++ b/rye/src/cli/add.rs
@@ -1,5 +1,4 @@
 use std::env;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::str::FromStr;
@@ -17,8 +16,8 @@ use crate::consts::VENV_BIN;
 use crate::pyproject::{BuildSystem, DependencyKind, ExpandedSources, PyProject};
 use crate::sources::py::PythonVersion;
 use crate::sync::{autosync, sync, SyncOptions};
-use crate::utils::{format_requirement, set_proxy_variables, CommandOutput};
-use crate::uv::Uv;
+use crate::utils::{format_requirement, get_venv_python_bin, set_proxy_variables, CommandOutput};
+use crate::uv::UvBuilder;
 
 const PACKAGE_FINDER_SCRIPT: &str = r#"
 import sys
@@ -448,43 +447,17 @@ fn resolve_requirements_with_uv(
     output: CommandOutput,
     default_operator: &Operator,
 ) -> Result<(), Error> {
+    let venv_path = pyproject_toml.venv_path();
+    let py_bin = get_venv_python_bin(&venv_path);
     for req in requirements {
-        let mut cmd = Uv::ensure_exists(output)?.cmd();
-        cmd.arg("pip")
-            .arg("compile")
-            .arg("--python-version")
-            .arg(py_ver.format_simple())
-            .arg("--no-deps")
-            .arg("--no-header")
-            .arg("-")
-            .env("VIRTUAL_ENV", pyproject_toml.venv_path().as_os_str());
-        if pre {
-            cmd.arg("--prerelease=allow");
-        }
-        if output == CommandOutput::Quiet {
-            cmd.arg("-q");
-        }
-        // this primarily exists for testing
-        if let Ok(dt) = env::var("__RYE_UV_EXCLUDE_NEWER") {
-            cmd.arg("--exclude-newer").arg(dt);
-        }
         let sources = ExpandedSources::from_sources(&pyproject_toml.sources()?)?;
-        sources.add_as_pip_args(&mut cmd);
-        let mut child = cmd
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()?;
-        let child_stdin = child.stdin.as_mut().unwrap();
-        writeln!(child_stdin, "{}", req)?;
 
-        let rv = child.wait_with_output()?;
-        if !rv.status.success() {
-            let log = String::from_utf8_lossy(&rv.stderr);
-            bail!("failed to resolve packages:\n{}", log);
-        }
-
-        let mut new_req: Requirement = String::from_utf8_lossy(&rv.stdout).parse()?;
+        let mut new_req = UvBuilder::new()
+            .with_output(output.quieter())
+            .with_sources(sources)
+            .ensure_exists()?
+            .venv(&venv_path, &py_bin, py_ver, None)?
+            .resolve(py_ver, req, pre, env::var("__RYE_UV_EXCLUDE_NEWER").ok())?;
 
         // if a version or URL is already provided we just use the normalized package name but
         // retain all old information.

--- a/rye/src/cli/add.rs
+++ b/rye/src/cli/add.rs
@@ -449,15 +449,16 @@ fn resolve_requirements_with_uv(
 ) -> Result<(), Error> {
     let venv_path = pyproject_toml.venv_path();
     let py_bin = get_venv_python_bin(&venv_path);
-    for req in requirements {
-        let sources = ExpandedSources::from_sources(&pyproject_toml.sources()?)?;
+    let sources = ExpandedSources::from_sources(&pyproject_toml.sources()?)?;
 
-        let mut new_req = UvBuilder::new()
-            .with_output(output.quieter())
-            .with_sources(sources)
-            .ensure_exists()?
-            .venv(&venv_path, &py_bin, py_ver, None)?
-            .resolve(py_ver, req, pre, env::var("__RYE_UV_EXCLUDE_NEWER").ok())?;
+    let uv = UvBuilder::new()
+        .with_output(output.quieter())
+        .with_sources(sources)
+        .ensure_exists()?
+        .venv(&venv_path, &py_bin, py_ver, None)?;
+
+    for req in requirements {
+        let mut new_req = uv.resolve(py_ver, req, pre, env::var("__RYE_UV_EXCLUDE_NEWER").ok())?;
 
         // if a version or URL is already provided we just use the normalized package name but
         // retain all old information.

--- a/rye/src/pyproject.rs
+++ b/rye/src/pyproject.rs
@@ -1283,7 +1283,6 @@ pub struct ExpandedSources {
 }
 
 impl ExpandedSources {
-    #[allow(unused)]
     pub fn empty() -> ExpandedSources {
         ExpandedSources {
             index_urls: Vec::new(),

--- a/rye/src/pyproject.rs
+++ b/rye/src/pyproject.rs
@@ -1283,6 +1283,15 @@ pub struct ExpandedSources {
 }
 
 impl ExpandedSources {
+    #[allow(unused)]
+    pub fn empty() -> ExpandedSources {
+        ExpandedSources {
+            index_urls: Vec::new(),
+            find_links: Vec::new(),
+            trusted_hosts: HashSet::new(),
+        }
+    }
+
     /// Takes some sources and expands them.
     pub fn from_sources(sources: &[SourceRef]) -> Result<ExpandedSources, Error> {
         let mut index_urls = Vec::new();

--- a/rye/src/sync.rs
+++ b/rye/src/sync.rs
@@ -80,6 +80,12 @@ pub struct VenvMarker {
     pub venv_path: Option<PathBuf>,
 }
 
+impl VenvMarker {
+    pub fn is_compatible(&self, py_ver: &PythonVersion) -> bool {
+        self.python == *py_ver
+    }
+}
+
 /// Synchronizes a project's virtualenv.
 pub fn sync(mut cmd: SyncOptions) -> Result<(), Error> {
     let pyproject = PyProject::load_or_discover(cmd.pyproject.as_deref())?;

--- a/rye/src/utils/mod.rs
+++ b/rye/src/utils/mod.rs
@@ -144,7 +144,7 @@ impl CommandOutput {
         }
     }
 
-    pub fn quieter(self) -> CommandOutput {
+    pub fn quieter(&self) -> CommandOutput {
         match self {
             CommandOutput::Normal => CommandOutput::Quiet,
             CommandOutput::Verbose => CommandOutput::Normal,

--- a/rye/src/uv.rs
+++ b/rye/src/uv.rs
@@ -324,6 +324,25 @@ impl UvWithVenv {
         Ok(())
     }
 
+    /// Freezes the venv.
+    pub fn freeze(&self) -> Result<(), Error> {
+        let status = self
+            .venv_cmd()
+            .arg("pip")
+            .arg("freeze")
+            .status()
+            .with_context(|| format!("unable to freeze venv at {}", self.venv_path.display()))?;
+
+        if !status.success() {
+            return Err(anyhow!(
+                "Failed to freeze venv at {}. uv exited with status: {}",
+                self.venv_path.display(),
+                status
+            ));
+        }
+
+        Ok(())
+    }
     /// Writes the tool version to the venv.
     pub fn write_tool_version(&self, version: u64) -> Result<(), Error> {
         let tool_version_path = self.venv_path.join("tool-version.txt");

--- a/rye/src/uv.rs
+++ b/rye/src/uv.rs
@@ -268,6 +268,15 @@ impl UvWithVenv {
         write_venv_marker(&self.venv_path, &self.py_version)
     }
 
+    #[allow(unused)]
+    pub fn with_output(self, output: CommandOutput) -> Self {
+        UvWithVenv {
+            uv: Uv { output, ..self.uv },
+            venv_path: self.venv_path,
+            py_version: self.py_version,
+        }
+    }
+
     /// Updates the venv to the given pip version and requirements.
     pub fn update(&self, pip_version: &str, requirements: &str) -> Result<(), Error> {
         self.update_pip(pip_version)?;

--- a/rye/src/uv.rs
+++ b/rye/src/uv.rs
@@ -150,20 +150,6 @@ impl Uv {
     /// and bootstrap it into [RYE_HOME]/uv/[version]/uv.
     ///
     /// See [`Uv::cmd`] to get access to the uv binary in a safe way.
-    ///
-    /// Example:
-    ///   ```rust
-    ///   use rye::sources::uv::Uv;
-    ///   use rye::utils::CommandOutput;
-    ///   let uv = Uv::ensure_exists(CommandOutput::Normal).expect("Failed to ensure uv binary is available");
-    ///   let status = uv.cmd().arg("--version").status().expect("Failed to run uv");
-    ///   assert!(status.success());
-    ///   ```
-    #[deprecated]
-    pub fn ensure_exists(output: CommandOutput) -> Result<Uv, Error> {
-        UvBuilder::new().with_output(output).ensure_exists()
-    }
-
     fn ensure(
         workdir: PathBuf,
         sources: ExpandedSources,

--- a/rye/src/uv.rs
+++ b/rye/src/uv.rs
@@ -37,7 +37,8 @@ impl Uv {
     ///   let status = uv.cmd().arg("--version").status().expect("Failed to run uv");
     ///   assert!(status.success());
     ///   ```
-    pub fn ensure_exists(output: CommandOutput) -> Result<Self, Error> {
+    #[deprecated]
+    pub fn ensure_exists(output: CommandOutput) -> Result<Uv, Error> {
         // Request a download for the default uv binary for this platform.
         // For instance on aarch64 macos this will request a compatible uv version.
         let download = UvDownload::try_from(UvRequest::default())?;


### PR DESCRIPTION
The pull requests moves all invocations of `uv` to `src/uv.rs`. The invokations are now structured into three main structures: 
- `UvBuilder`, which can be used to create a new instance of a `uv` binary that ensures `uv` exists on disk. 
- `Uv`, which provides operations using `uv` outside of the virtual environment, for example creating a venv, compiling lockfiles ,etc.
- `UvWithVenv`, which must be obtained using `Uv::venv()` to guarantee a venv is available, which encapsulates operations on the venv.

This opens the door to implement the same patterns for `pip-tools` and intorduce a trait to use dynamic dispatching instead of the existing `if/else` structure. If we continue down this path, we can hopefully in the future just do:

```rs
// Create either PipTools or Uv instance, returns `Box<PipLikeTool>`
PipBuilder::use_uv(Config::use_uv())
   .build()
   .with_output(output)
   .venv(...);
```
## Important Note:
Note that the changes are not 100% equivalent to the previous code. Most notable, in order to operate on a venv, all codepaths must go through `Uv::venv`, which will always check if the existing venv is compatbile. This is a safer, but more expensive path (since we at least always read the marker). If we are worried about this, we can introduce an `assume_venv` which will return `UvWithVenv` without checks.