### PR TITLE
fix: rye test output format uncorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ that were not yet released.
 
 _Unreleased_
 
+- Fix incorrect flag passing of `rye test` `-q` and `-v`.  #880
+
 <!-- released start -->
 
 ## 0.29.0

--- a/rye/src/cli/test.rs
+++ b/rye/src/cli/test.rs
@@ -101,10 +101,10 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
         match output {
             CommandOutput::Normal => {}
             CommandOutput::Verbose => {
-                pytest_cmd.arg("-q");
+                pytest_cmd.arg("-v");
             }
             CommandOutput::Quiet => {
-                pytest_cmd.arg("-v");
+                pytest_cmd.arg("-q");
             }
         }
         pytest_cmd.args(&cmd.extra_args);


### PR DESCRIPTION
rye test output format uncorrect
fix #879 