### PR TITLE
Ignore `target` when running `pytest` in rye

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,6 @@ serve-docs = "mkdocs serve"
 
 [tool.rye.workspace]
 members = ["rye-devtools"]
+
+[tool.pytest.ini_options]
+addopts = "--ignore target"


### PR DESCRIPTION
rye puts testing Python toolchains inside `target/debug/rye-test-home/py`. When you run `pytest`, it searches `target` and inadvertently picks up Python standard library tests, resulting in thousands of test cases to run. We should ignore `target` when running pytest in rye project.
