### PR TITLE
FIX: Docs Pypi default link

### DIFF
--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -98,7 +98,7 @@ venv-mark-sync-ignore = true
 # a array of tables with optional sources.  Same format as in pyproject.toml
 [[sources]]
 name = "default"
-url = "http://pypi.org/simple/"
+url = "https://pypi.org/simple/"
 ```
 
 ## Manipulating Config


### PR DESCRIPTION
Fixing the default Pypi index in the config [[source]] part.
`pip install -h` yields
![image](https://github.com/astral-sh/rye/assets/57259263/e9484904-5add-4b73-b389-375aa5930411)

with the http version I get the following error with uv enabled:
![image](https://github.com/astral-sh/rye/assets/57259263/b06daf3a-6918-4ef6-a139-5c57bad1d991)

After fixing to `https` rye add works without problems