### PR TITLE
rye test: Don't enable capture=no in quiet mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ that were not yet released.
 _Unreleased_
 
 - Allow `rye publish` working outside of project.  #910
+- `rye test --quiet` no longer implies `--no-capture`. #915
 
 <!-- released start -->
 

--- a/rye/src/cli/test.rs
+++ b/rye/src/cli/test.rs
@@ -95,7 +95,7 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
         }
 
         let mut pytest_cmd = Command::new(&pytest);
-        if cmd.no_capture || output == CommandOutput::Quiet {
+        if cmd.no_capture {
             pytest_cmd.arg("--capture=no");
         }
         match output {


### PR DESCRIPTION
rye test -q behaves like pytest -q -s, but the extra -s (no capture == show all standard output) is surprising.

This seems out of place but I don't know if it was deliberate - I suggest this change.