### PR TITLE
Installer now recommends uv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ _Unreleased_
   than having interpreters at `~/.rye/py/cpython@3.11.1/install/bin/python3`
   it will now reside at `~/.rye/py/cpython@3.11.1/bin/python3`.  #917
 
+- Installer now recommends `uv` over `pip-tools`.
+
 <!-- released start -->
 
 ## 0.30.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ _Unreleased_
   than having interpreters at `~/.rye/py/cpython@3.11.1/install/bin/python3`
   it will now reside at `~/.rye/py/cpython@3.11.1/bin/python3`.  #917
 
-- Installer now recommends `uv` over `pip-tools`.
+- Installer now recommends `uv` over `pip-tools`.  #918
 
 <!-- released start -->
 

--- a/rye/src/cli/rye.rs
+++ b/rye/src/cli/rye.rs
@@ -548,15 +548,15 @@ fn perform_install(
         .and_then(|x| x.get("use-uv"))
         .is_none()
         && !matches!(mode, InstallMode::NoPrompts)
-        && dialoguer::Select::with_theme(tui_theme())
+    {
+        let use_uv = dialoguer::Select::with_theme(tui_theme())
             .with_prompt("Select the preferred package installer")
-            .item("pip-tools (slow but stable)")
-            .item("uv (quick but experimental)")
+            .item("uv (fast, recommended)")
+            .item("pip-tools (slow, higher compatibility)")
             .default(0)
             .interact()?
-            == 1
-    {
-        toml::ensure_table(config_doc, "behavior")["use-uv"] = toml_edit::value(true);
+            == 0;
+        toml::ensure_table(config_doc, "behavior")["use-uv"] = toml_edit::value(use_uv);
     }
 
     // If the global-python flag is not in the settings, ask the user if they want to turn

--- a/rye/src/config.rs
+++ b/rye/src/config.rs
@@ -260,7 +260,7 @@ impl Config {
             .unwrap_or_else(|| self.use_uv())
     }
 
-    /// Indicates if the experimental uv support should be used.
+    /// Indicates if uv should be used instead of pip-tools.
     pub fn use_uv(&self) -> bool {
         self.doc
             .get("behavior")


### PR DESCRIPTION
The default is still `pip-tools` but the installer now recommends uv.