### PR TITLE
Update pep508_rs and pep440_rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1867,6 +1867,7 @@ dependencies = [
  "once_cell",
  "pathdiff",
  "pep440_rs 0.5.0",
+ "pep508_rs 0.3.0",
  "pep508_rs 0.4.2",
  "python-pkginfo",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,6 +530,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,7 +1277,7 @@ dependencies = [
  "cpufeatures",
  "fs-err",
  "fs2",
- "pep508_rs",
+ "pep508_rs 0.3.0",
  "regex",
  "serde",
  "serde_json",
@@ -1416,19 +1427,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "pep440_rs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15efd4d885c29126cc93e12af3087896e2518bd5ca0fb328c19c4ef9cecfa8be"
+dependencies = [
+ "once_cell",
+ "unicode-width",
+ "unscanny",
+]
+
+[[package]]
 name = "pep508_rs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "910c513bea0f4f833122321c0f20e8c704e01de98692f6989c2ec21f43d88b1e"
 dependencies = [
  "once_cell",
- "pep440_rs",
+ "pep440_rs 0.4.0",
  "regex",
  "serde",
  "thiserror",
  "tracing",
  "unicode-width",
  "url",
+]
+
+[[package]]
+name = "pep508_rs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1455babf8edd3eedcdfcb39700e455a4bb189e71b4f1fa0eacc9b244cc5a55e6"
+dependencies = [
+ "derivative",
+ "once_cell",
+ "pep440_rs 0.5.0",
+ "regex",
+ "thiserror",
+ "unicode-width",
+ "url",
+ "urlencoding",
 ]
 
 [[package]]
@@ -1828,8 +1866,8 @@ dependencies = [
  "monotrail-utils",
  "once_cell",
  "pathdiff",
- "pep440_rs",
- "pep508_rs",
+ "pep440_rs 0.5.0",
+ "pep508_rs 0.4.2",
  "python-pkginfo",
  "regex",
  "same-file",
@@ -2092,6 +2130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -2414,6 +2453,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "vcpkg"

--- a/rye/Cargo.toml
+++ b/rye/Cargo.toml
@@ -27,8 +27,8 @@ license = { version = "3.1.1", features = ["offline"] }
 minijinja = { version = "2.0.1", features = ["json"] }
 once_cell = "1.17.1"
 pathdiff = "0.2.1"
-pep440_rs = "0.4.0"
-pep508_rs = "0.3.0"
+pep440_rs = "0.5.0"
+pep508_rs = "0.4.2"
 regex = "1.8.1"
 same-file = "1.0.6"
 serde = { version = "1.0.160", features = ["derive"] }

--- a/rye/Cargo.toml
+++ b/rye/Cargo.toml
@@ -29,6 +29,7 @@ once_cell = "1.17.1"
 pathdiff = "0.2.1"
 pep440_rs = "0.5.0"
 pep508_rs = "0.4.2"
+pep508_v030 = { version = "0.3.0", package = "pep508_rs" }
 regex = "1.8.1"
 same-file = "1.0.6"
 serde = { version = "1.0.160", features = ["derive"] }

--- a/rye/src/cli/init.rs
+++ b/rye/src/cli/init.rs
@@ -701,7 +701,8 @@ fn import_requirements_file(
     data.requirements.iter().for_each(|x| {
         requirements
             .entry(x.requirement.name.to_string())
-            .or_insert(format_requirement(&x.requirement).to_string());
+            // todo: will to_string this work?
+            .or_insert(x.requirement.to_string());
     });
     Ok(())
 }

--- a/rye/src/cli/init.rs
+++ b/rye/src/cli/init.rs
@@ -25,8 +25,8 @@ use crate::platform::{
 use crate::pyproject::BuildSystem;
 use crate::sources::py::PythonVersionRequest;
 use crate::utils::{
-    copy_dir, escape_string, format_requirement, get_venv_python_bin, is_inside_git_work_tree,
-    CommandOutput, CopyDirOptions, IoPathContext,
+    copy_dir, escape_string, format_requirement, format_requirement_v030, get_venv_python_bin,
+    is_inside_git_work_tree, CommandOutput, CopyDirOptions, IoPathContext,
 };
 
 /// Initialize a new or existing Python project with Rye.
@@ -701,8 +701,7 @@ fn import_requirements_file(
     data.requirements.iter().for_each(|x| {
         requirements
             .entry(x.requirement.name.to_string())
-            // todo: will to_string this work?
-            .or_insert(x.requirement.to_string());
+            .or_insert(format_requirement_v030(&x.requirement).to_string());
     });
     Ok(())
 }

--- a/rye/src/cli/test.rs
+++ b/rye/src/cli/test.rs
@@ -11,7 +11,7 @@ use same_file::is_same_file;
 use crate::config::Config;
 use crate::consts::VENV_BIN;
 use crate::lock::KeyringProvider;
-use crate::pyproject::{locate_projects, normalize_package_name, DependencyKind, PyProject};
+use crate::pyproject::{locate_projects, DependencyKind, PyProject};
 use crate::sync::autosync;
 use crate::utils::{CommandOutput, QuietExit};
 
@@ -145,7 +145,7 @@ fn has_pytest_dependency(projects: &[PyProject]) -> Result<bool, Error> {
             .chain(project.iter_dependencies(DependencyKind::Normal))
         {
             if let Ok(req) = dep.expand(|name| std::env::var(name).ok()) {
-                if normalize_package_name(&req.name) == "pytest" {
+                if req.name.as_ref() == "pytest" {
                     return Ok(true);
                 }
             }

--- a/rye/src/pyproject.rs
+++ b/rye/src/pyproject.rs
@@ -1039,7 +1039,7 @@ fn set_dependency(deps: &mut Array, req: &Requirement) {
     for (idx, dep) in deps.iter().enumerate() {
         if let Some(dep) = dep.as_str() {
             if let Ok(dep_req) = Requirement::from_str(dep) {
-                if dep_req.name.eq_ignore_ascii_case(&req.name) {
+                if dep_req.name == req.name {
                     to_replace = Some(idx);
                     break;
                 }
@@ -1061,7 +1061,7 @@ fn remove_dependency(deps: &mut Array, req: &Requirement) -> Option<Requirement>
     for (idx, dep) in deps.iter().enumerate() {
         if let Some(dep) = dep.as_str() {
             if let Ok(dep_req) = Requirement::from_str(dep) {
-                if dep_req.name.eq_ignore_ascii_case(&req.name) {
+                if dep_req.name == req.name {
                     to_remove = Some(idx);
                     break;
                 }

--- a/rye/src/sources/py.rs
+++ b/rye/src/sources/py.rs
@@ -116,31 +116,23 @@ impl fmt::Display for PythonVersion {
 
 impl From<PythonVersion> for Version {
     fn from(value: PythonVersion) -> Self {
-        Version {
-            epoch: 0,
-            release: vec![value.major as u64, value.minor as u64, value.patch as u64],
-            pre: None,
-            post: None,
-            dev: None,
-            local: None,
-        }
+        Version::new(vec![
+            value.major as u64,
+            value.minor as u64,
+            value.patch as u64,
+        ])
+        .with_epoch(0)
     }
 }
 
 impl From<PythonVersionRequest> for Version {
     fn from(value: PythonVersionRequest) -> Self {
-        Version {
-            epoch: 0,
-            release: vec![
-                value.major as u64,
-                value.minor.unwrap_or_default() as u64,
-                value.patch.unwrap_or_default() as u64,
-            ],
-            pre: None,
-            post: None,
-            dev: None,
-            local: None,
-        }
+        Version::new(vec![
+            value.major as u64,
+            value.minor.unwrap_or_default() as u64,
+            value.patch.unwrap_or_default() as u64,
+        ])
+        .with_epoch(0)
     }
 }
 
@@ -214,9 +206,9 @@ impl From<Version> for PythonVersionRequest {
             name: None,
             arch: None,
             os: None,
-            major: value.release.first().map(|x| *x as _).unwrap_or(3),
-            minor: value.release.get(1).map(|x| *x as _),
-            patch: value.release.get(2).map(|x| *x as _),
+            major: value.release().first().map(|x| *x as _).unwrap_or(3),
+            minor: value.release().get(1).map(|x| *x as _),
+            patch: value.release().get(2).map(|x| *x as _),
             suffix: None,
         }
     }

--- a/rye/src/utils/mod.rs
+++ b/rye/src/utils/mod.rs
@@ -197,8 +197,17 @@ pub fn format_requirement(req: &Requirement) -> impl fmt::Display + '_ {
     impl<'x> fmt::Display for Helper<'x> {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             write!(f, "{}", self.0.name)?;
-            if let Some(extras) = &self.0.extras {
-                write!(f, "[{}]", extras.join(","))?;
+            if !self.0.extras.is_empty() {
+                write!(
+                    f,
+                    "[{}]",
+                    self.0
+                        .extras
+                        .iter()
+                        .map(|x| x.as_ref())
+                        .collect::<Vec<_>>()
+                        .join(",")
+                )?;
             }
             if let Some(version_or_url) = &self.0.version_or_url {
                 match version_or_url {
@@ -208,12 +217,12 @@ pub fn format_requirement(req: &Requirement) -> impl fmt::Display + '_ {
                         write!(f, "{}", version_specifier.join(", "))?;
                     }
                     VersionOrUrl::Url(url) => {
-                        // retain `{` and `}` for interpolation in URLs
-                        write!(
-                            f,
-                            " @ {}",
-                            url.to_string().replace("%7B", "{").replace("%7D", "}")
-                        )?;
+                        // Use given url if present in VerbatimUrl
+                        if let Some(given) = url.given() {
+                            write!(f, " @ {}", given)?;
+                        } else {
+                            write!(f, " @ {}", url)?;
+                        }
                     }
                 }
             }

--- a/rye/tests/common/mod.rs
+++ b/rye/tests/common/mod.rs
@@ -56,6 +56,7 @@ use-uv = true
 
 [default]
 toolchain = "cpython@3.12.3"
+author = "Test User <test@example.com>"
 "#,
         )
         .unwrap();

--- a/rye/tests/common/mod.rs
+++ b/rye/tests/common/mod.rs
@@ -255,3 +255,14 @@ macro_rules! rye_cmd_snapshot {
 
 #[allow(unused_imports)]
 pub(crate) use rye_cmd_snapshot;
+
+#[allow(unused)]
+pub fn toml_array_as_string_array(arr: &toml_edit::Array) -> Vec<String> {
+    arr.iter()
+        .map(|x| {
+            x.as_str()
+                .map(|x| x.to_string())
+                .unwrap_or_else(|| x.to_string())
+        })
+        .collect()
+}


### PR DESCRIPTION
Update pep508_rs and pep440_rs crates

Main reason is to use VerbatimUrl from pep508_rs and try to fix issues around file:///${PROJECT_ROOT}/etc dependencies.

Note that monotrail-utils is still using the older pep508_rs.

Fixes #912 