### PR TITLE
Ignore build-system configuration for virtual projects

### DIFF
--- a/rye/src/pyproject.rs
+++ b/rye/src/pyproject.rs
@@ -822,12 +822,21 @@ impl PyProject {
             .get("build-system")
             .and_then(|x| x.get("build-backend"))
             .and_then(|x| x.as_str());
-        match backend {
+        let build_system = match backend {
             Some("hatchling.build") => Some(BuildSystem::Hatchling),
             Some("setuptools.build_meta") => Some(BuildSystem::Setuptools),
             Some("flit_core.buildapi") => Some(BuildSystem::Flit),
             Some("pdm.backend") => Some(BuildSystem::Pdm),
             _ => None,
+        };
+        if self.is_virtual() && build_system.is_some() {
+            warn!(
+                "project '{}' is virtual but defines build-system",
+                self.name().unwrap_or("")
+            );
+            None
+        } else {
+            build_system
         }
     }
     /// Looks up a script


### PR DESCRIPTION
This change done for its effect on the add command too. We should ignore build-system for rye purposes, if the project is configured as virtual. The warning is useful because other tools might not handle this the same way - it is best to remove the unused configuration(?)