### PR TITLE
Fix `rye fetch` detection of registered toolchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ _Unreleased_
 
 - Always create `.gitignore` file in `rye init`.  #919
 
+- Fix rye fetch detection of registered toolchain. #931
+
 <!-- released start -->
 
 ## 0.31.0

--- a/rye/src/bootstrap.rs
+++ b/rye/src/bootstrap.rs
@@ -400,7 +400,7 @@ pub fn fetch(
         None => {
             let target_dir = get_canonical_py_path(&version)?;
             let target_py_bin = get_toolchain_python_bin(&version)?;
-            if target_dir.is_dir() && target_py_bin.is_file() {
+            if target_py_bin.is_file() {
                 if !options.force {
                     echo!(if verbose options.output, "Python version already downloaded. Skipping.");
                     return Ok(version);

--- a/rye/src/bootstrap.rs
+++ b/rye/src/bootstrap.rs
@@ -379,6 +379,16 @@ pub fn fetch(
     version: &PythonVersionRequest,
     options: FetchOptions,
 ) -> Result<PythonVersion, Error> {
+    // Check if there is registered toolchain that matches the request
+    if options.target_path.is_none() {
+        if let Ok(version) = PythonVersion::try_from(version.clone()) {
+            let py_bin = get_toolchain_python_bin(&version)?;
+            if !options.force && py_bin.is_file() {
+                echo!(if verbose options.output, "Python version already downloaded. Skipping.");
+                return Ok(version);
+            }
+        }
+    }
     let (version, url, sha256) = match get_download_url(version) {
         Some(result) => result,
         None => bail!("unknown version {}", version),


### PR DESCRIPTION
Registered toolchain can be a symlink to `python.exe`, before `0.31.0`, we use `py_bin.is_file()` to detect:
https://github.com/astral-sh/rye/blob/c7cbdd955cf494f905e5388e49677149a58028c2/rye/src/bootstrap.rs#L348-L350

Fixes #926 
