### PR TITLE
Correct syntax when calling `eval` on completion command documentation

### DIFF
--- a/docs/guide/commands/self/completion.md
+++ b/docs/guide/commands/self/completion.md
@@ -7,7 +7,7 @@ Generates a completion script for a shell
 Generate a completion script for zsh and load it:
 
 ```
-$ eval (rye self completion -s zsh)
+$ eval "$(rye self completion -s zsh)"
 ```
 
 ## Arguments


### PR DESCRIPTION
corrects a syntax mistake when calling `eval` in the documentation for zsh shell completion 