### PR TITLE
Fix verbose/quiet for rye lint and format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ _Unreleased_
 
 - Always create `.gitignore` file in `rye init`.  #919
 
+- Fix error on using -v or -q with `rye fmt` or `rye lint`. #959
+
 <!-- released start -->
 
 ## 0.31.0

--- a/rye/src/utils/ruff.rs
+++ b/rye/src/utils/ruff.rs
@@ -48,16 +48,18 @@ pub fn execute_ruff(args: RuffArgs, extra_args: &[&str]) -> Result<(), Error> {
             project.workspace_path().join(".ruff_cache"),
         );
     }
+    ruff_cmd.args(extra_args);
+
     match output {
         CommandOutput::Normal => {}
         CommandOutput::Verbose => {
             ruff_cmd.arg("--verbose");
         }
         CommandOutput::Quiet => {
-            ruff_cmd.arg("-q");
+            ruff_cmd.arg("--quiet");
         }
     }
-    ruff_cmd.args(extra_args);
+
     ruff_cmd.args(args.extra_args);
 
     ruff_cmd.arg("--");


### PR DESCRIPTION
These commands produced `ruff --verbose check`  (same for --quiet and same for format) but the verbose/quiet need to come after the subcommand. The command would produce an error (file `check`/`format` does not exist), now it succeeds.

Fixes #956