### PR TITLE
rye fmt ruff extra args error (degrade)

### DIFF
--- a/rye/src/utils/ruff.rs
+++ b/rye/src/utils/ruff.rs
@@ -48,7 +48,6 @@ pub fn execute_ruff(args: RuffArgs, extra_args: &[&str]) -> Result<(), Error> {
             project.workspace_path().join(".ruff_cache"),
         );
     }
-    ruff_cmd.args(extra_args);
 
     match output {
         CommandOutput::Normal => {}
@@ -60,6 +59,7 @@ pub fn execute_ruff(args: RuffArgs, extra_args: &[&str]) -> Result<(), Error> {
         }
     }
 
+    ruff_cmd.args(extra_args);
     ruff_cmd.args(args.extra_args);
 
     ruff_cmd.arg("--");


### PR DESCRIPTION
Fixed the following error:

```sh
$ rye fmt -q -- --select I --fix
error: unexpected argument '--select' found

  tip: to pass '--select' as a value, use '-- --select'

Usage: ruff format <--verbose|--quiet|--silent> [FILES]...

For more information, try '--help'.
```