### PR TITLE
Preserve trailing newline in templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ that were not yet released.
 
 _Unreleased_
 
+- Ensure files created by `rye init`, such as `pyproject.toml` and initial
+  python files end with a newline. #979
+
 <!-- released start -->
 
 ## 0.32.0

--- a/rye/src/cli/init.rs
+++ b/rye/src/cli/init.rs
@@ -152,7 +152,8 @@ if __name__ == "setuptools":
 
 pub fn execute(cmd: Args) -> Result<(), Error> {
     let cfg = Config::current();
-    let env = Environment::new();
+    let mut env = Environment::new();
+    env.set_keep_trailing_newline(true);
     let dir = env::current_dir()?.join(cmd.path);
     let toml = dir.join("pyproject.toml");
     let readme = dir.join("README.md");


### PR DESCRIPTION
Let initial files like pyproject.toml, .gitignore, \_\_init\_\_.py etc all keep their trailing newline so that they finish with a (single) newline.

Fixes #950 