### PR TITLE
DOC: correct black run command and refine text

### DIFF
--- a/docs/guide/basics.md
+++ b/docs/guide/basics.md
@@ -98,12 +98,13 @@ rye remove flask
 ## Working with the Project
 
 To run executables in the context of the virtualenv you can use the `run` command.  For
-instance if you want to use `black` you can add and run it like this:
+instance, if you want to use `black` you can add, install, and run it on the current
+directory like this:
 
 ```
 rye add black
 rye sync
-rye run black
+rye run black .
 ```
 
 If you want to have the commands available directly you will need to activate the

--- a/docs/guide/basics.md
+++ b/docs/guide/basics.md
@@ -97,9 +97,9 @@ rye remove flask
 
 ## Working with the Project
 
-To run executables in the context of the virtualenv you can use the `run` command.  For
-instance, if you want to use `black` you can add, install, and run it on the current
-directory like this:
+To run executables in the context of the virtualenv you can use the `run` command. For
+instance, to use `black`, add it to the project, sync the virtual environment, and run it
+over the current directory like this:
 
 ```
 rye add black


### PR DESCRIPTION
This PR corrects the run command which will error if black is not given a directory to check. Refined wording to reinforce "add-install-run" steps.