### PR TITLE
Add `--refresh` argument on `-f`

### DIFF
--- a/rye/src/installer.rs
+++ b/rye/src/installer.rs
@@ -153,6 +153,7 @@ pub fn install(
                 UvInstallOptions {
                     importlib_workaround: py_ver.major == 3 && py_ver.minor == 7,
                     extras: extra_requirements.to_vec(),
+                    refresh: force,
                 },
             );
         if result.is_err() {

--- a/rye/src/uv.rs
+++ b/rye/src/uv.rs
@@ -20,6 +20,7 @@ use tempfile::NamedTempFile;
 pub struct UvInstallOptions {
     pub importlib_workaround: bool,
     pub extras: Vec<Requirement>,
+    pub refresh: bool,
 }
 
 pub enum UvPackageUpgrade {
@@ -27,7 +28,7 @@ pub enum UvPackageUpgrade {
     All,
     /// Upgrade the specific set of packages.
     Packages(Vec<String>),
-    /// Upgrade nothig (default).
+    /// Upgrade nothing (default).
     Nothing,
 }
 
@@ -469,6 +470,10 @@ impl UvWithVenv {
         let mut cmd = self.venv_cmd();
 
         cmd.arg("pip").arg("install");
+
+        if options.refresh {
+            cmd.arg("--refresh");
+        }
 
         self.uv.sources.add_as_pip_args(&mut cmd);
 


### PR DESCRIPTION
## Summary

Ensures that we rebuild any local packages when you run with `-f`.

Closes https://github.com/astral-sh/rye/issues/984.

## Test Plan

```
❯ cargo run install ../uv/scripts/packages/black_editable -f
   Compiling rye v0.33.0 (/Users/crmarsh/workspace/rye/rye)
    Finished dev [unoptimized + debuginfo] target(s) in 1.18s
     Running `target/debug/rye install ../uv/scripts/packages/black_editable -f`
Resolved 1 package in 0.91ms
   Built black @ file:///Users/crmarsh/workspace/uv/scripts/packages/black_editable                                                                                                                                                           Downloaded 1 package in 132ms
Installed 1 package in 0.60ms
 + black==0.1.0 (from file:///Users/crmarsh/workspace/uv/scripts/packages/black_editable)
```