### PR TITLE
Add `autosync-before-run`, `--sync` and `--no-sync` arguments to `test` (`Regular` sync mode)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 .idea
 token.txt
 dist
+**/*.rs.pending-snap

--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -89,6 +89,10 @@ use-uv = false
 # to `true` when uv is enabled and `false` otherwise.
 autosync = true
 
+# Enable or disable automatic `sync` ahead of `run` and `test`.  This defaults
+# to `true` when uv is enabled and `false` otherwise.
+autosync-before-run = true
+
 # Marks the managed .venv in a way that cloud based synchronization systems
 # like Dropbox and iCloud Files will not upload it.  This defaults to true
 # as a .venv in cloud storage typically does not make sense.  Set this to

--- a/rye/src/cli/run.rs
+++ b/rye/src/cli/run.rs
@@ -8,10 +8,11 @@ use anyhow::{bail, Context, Error};
 use clap::Parser;
 use console::style;
 
+use crate::config::Config;
 use crate::pyproject::{PyProject, Script};
-use crate::sync::{sync, SyncOptions};
+use crate::sync::{autosync, sync, SyncOptions};
 use crate::tui::redirect_to_stderr;
-use crate::utils::{exec_spawn, get_venv_python_bin, success_status, IoPathContext};
+use crate::utils::{exec_spawn, get_venv_python_bin, success_status, CommandOutput, IoPathContext};
 
 /// Runs a command installed into this package.
 #[derive(Parser, Debug)]
@@ -26,6 +27,18 @@ pub struct Args {
     /// Use this pyproject.toml file
     #[arg(long, value_name = "PYPROJECT_TOML")]
     pyproject: Option<PathBuf>,
+    /// Runs `sync` even if auto-sync is disabled.
+    #[arg(long)]
+    sync: bool,
+    /// Does not run `sync` even if auto-sync is enabled.
+    #[arg(long, conflicts_with = "sync")]
+    no_sync: bool,
+    /// Enables verbose diagnostics.
+    #[arg(short, long)]
+    verbose: bool,
+    /// Turns off all output.
+    #[arg(short, long, conflicts_with = "verbose")]
+    quiet: bool,
 }
 
 #[derive(Parser, Debug)]
@@ -36,11 +49,16 @@ enum Cmd {
 
 pub fn execute(cmd: Args) -> Result<(), Error> {
     let _guard = redirect_to_stderr(true);
+    let output = CommandOutput::from_quiet_and_verbose(cmd.quiet, cmd.verbose);
     let pyproject = PyProject::load_or_discover(cmd.pyproject.as_deref())?;
 
-    // make sure we have the minimal virtualenv.
-    sync(SyncOptions::python_only().pyproject(cmd.pyproject))
-        .context("failed to sync ahead of run")?;
+    if (Config::current().autosync_before_run() && !cmd.no_sync) || cmd.sync {
+        autosync(&pyproject, output)?;
+    } else {
+        // make sure we have the minimal virtualenv. 
+        sync(SyncOptions::python_only().pyproject(cmd.pyproject))
+            .context("failed to sync ahead of run")?;
+    }
 
     if cmd.list || cmd.cmd.is_none() {
         return list_scripts(&pyproject);

--- a/rye/src/cli/test.rs
+++ b/rye/src/cli/test.rs
@@ -31,6 +31,12 @@ pub struct Args {
     // Disable test output capture to stdout
     #[arg(long = "no-capture", short = 's')]
     no_capture: bool,
+    /// Runs `sync` even if auto-sync is disabled.
+    #[arg(long)]
+    sync: bool,
+    /// Does not run `sync` even if auto-sync is enabled.
+    #[arg(long, conflicts_with = "sync")]
+    no_sync: bool,
     /// Enables verbose diagnostics.
     #[arg(short, long)]
     verbose: bool,
@@ -72,7 +78,7 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
     if !pytest.is_file() {
         let has_pytest = has_pytest_dependency(&projects)?;
         if has_pytest {
-            if Config::current().autosync() {
+            if (Config::current().autosync_before_run() && !cmd.no_sync) || cmd.sync {
                 autosync(&projects[0], output)?;
             } else {
                 bail!("pytest not installed but in dependencies. Run `rye sync`.")

--- a/rye/src/config.rs
+++ b/rye/src/config.rs
@@ -251,11 +251,20 @@ impl Config {
         Ok(rv)
     }
 
-    /// Enable autosync.
+    /// Enable autosync for `add` and `remove`.
     pub fn autosync(&self) -> bool {
         self.doc
             .get("behavior")
             .and_then(|x| x.get("autosync"))
+            .and_then(|x| x.as_bool())
+            .unwrap_or_else(|| self.use_uv())
+    }
+ 
+    /// Enable autosync for `run` and `test`.
+    pub fn autosync_before_run(&self) -> bool {
+        self.doc
+            .get("behavior")
+            .and_then(|x| x.get("autosync-before-run"))
             .and_then(|x| x.as_bool())
             .unwrap_or_else(|| self.use_uv())
     }

--- a/rye/tests/test_cli.rs
+++ b/rye/tests/test_cli.rs
@@ -47,5 +47,11 @@ fn test_dotenv() {
     42 23
 
     ----- stderr -----
+    Reusing already existing virtualenv
+    Generating production lockfile: [TEMP_PATH]/project/requirements.lock
+    Generating dev lockfile: [TEMP_PATH]/project/requirements-dev.lock
+    Installing dependencies
+    Audited 1 package in [EXECUTION_TIME]
+    Done!
     "###);
 }

--- a/rye/tests/test_init.rs
+++ b/rye/tests/test_init.rs
@@ -41,6 +41,12 @@ fn test_init_lib() {
         Hello from my-project!
 
         ----- stderr -----
+        Reusing already existing virtualenv
+        Generating production lockfile: [TEMP_PATH]/project/requirements.lock
+        Generating dev lockfile: [TEMP_PATH]/project/requirements-dev.lock
+        Installing dependencies
+        Audited 1 package in [EXECUTION_TIME]
+        Done!    
     "###);
 
     assert!(
@@ -89,6 +95,12 @@ fn test_init_default() {
         Hello from my-project!
 
         ----- stderr -----
+        Reusing already existing virtualenv
+        Generating production lockfile: [TEMP_PATH]/project/requirements.lock
+        Generating dev lockfile: [TEMP_PATH]/project/requirements-dev.lock
+        Installing dependencies
+        Audited 1 package in [EXECUTION_TIME]
+        Done!    
     "###);
 
     assert!(
@@ -138,6 +150,12 @@ fn test_init_script() {
         Hello from my-project!
 
         ----- stderr -----
+        Reusing already existing virtualenv
+        Generating production lockfile: [TEMP_PATH]/project/requirements.lock
+        Generating dev lockfile: [TEMP_PATH]/project/requirements-dev.lock
+        Installing dependencies
+        Audited 1 package in [EXECUTION_TIME]
+        Done!    
     "###);
 
     rye_cmd_snapshot!(space.rye_cmd().arg("run").arg("python").arg("-mmy_project"), @r###"
@@ -147,6 +165,12 @@ fn test_init_script() {
         Hello from my-project!
 
         ----- stderr -----
+        Reusing already existing virtualenv
+        Generating production lockfile: [TEMP_PATH]/project/requirements.lock
+        Generating dev lockfile: [TEMP_PATH]/project/requirements-dev.lock
+        Installing dependencies
+        Audited 1 package in [EXECUTION_TIME]
+        Done!    
     "###);
 }
 


### PR DESCRIPTION
This PR adds:

- `--sync`/`--no-sync` flag arguments to `run` and `test` commands. They control whether Rye should install project dependencies prior to executing either command.
- `sync-before-run` global configuration flag that controls the same thing.

Closes #886.