### PR TITLE
Enables explicit root setting for [tool.rye.workspace] table

### DIFF
--- a/rye/src/pyproject.rs
+++ b/rye/src/pyproject.rs
@@ -386,7 +386,8 @@ impl Workspace {
             .map(|workspace| {
                 // take explicit search root from tool.rye.workspace.root if
                 // specified
-                let search_root = workspace.get("root")
+                let search_root = workspace
+                    .get("root")
                     .and_then(|p| p.as_str())
                     .and_then(|p| {
                         let path = PathBuf::from(p).canonicalize();
@@ -448,7 +449,7 @@ impl Workspace {
         Cow::Borrowed(&self.root)
     }
 
-    /// Checks if a project is a member of the declared workspace, 
+    /// Checks if a project is a member of the declared workspace,
     /// relative to a specific root.
     fn is_member_rooted(&self, path: &Path, root: &Path) -> bool {
         if let Ok(relative) = path.strip_prefix(root) {
@@ -500,7 +501,7 @@ impl Workspace {
                     // search explicit root
                     self.is_member_rooted(path, &self.search_root)
                 }
-            },
+            }
         }
     }
 


### PR DESCRIPTION
## Problem
Wanted to take a crack at solving my specific problem in #856. Repeated here:

In a monorepo I am working on, there is the following structure:
```
monorepo
  project0
  project1 ← project0
  project2 ← project0
```

Each project should be usable independently and their dependencies may conflict (so a top level workspace does not apply). I would like for users of the repo to be able to `rye sync` in `monorepo/project1` when they need to work on that project and have an editable install of `monorepo/project0`. 

Above I only showed a single dependencies per project, but in the future there may be more than one dependency from the monorepo for a given project, e.g., `project4`:
```
monorepo
  project0
  project1 ← project0
  project2 ← project0
  project3
  project4 ← project0, project3
```

## Solution
By setting the `root` key in the `[tool.rye.workspace]` table one can now explicitly override the search root for projects for the relevant project's workspace. Project membership (i.e., `is_member`) is first checked as before, using the current project's root, and then is checked using the explicitly specified search root (if applicable).

This might not be the final answer (e.g., it might be nice to be able to control the search root on a per member basis, where members could optionally become inline tables with `name` (the current glob pattern) and `root` keys), but it's a good starting point.

Given this is my first time looking at the `rye` code base, and my Rust is not expert level, I'd appreciate feedback here. I left a TODO related to error handling in the case when the root key results in an `Error`.

Happy to hear discussion about this PR, it solves my problem for the moment so I hope we can get in it `rye` in some form in the near future because I can't use it in my project until there is some way to handle this scenario.