### PR TITLE
Include sources in lockfile

### DIFF
--- a/rye/src/lock.rs
+++ b/rye/src/lock.rs
@@ -493,12 +493,7 @@ fn finalize_lockfile(
         .path_context(generated, "unable to parse resolver output")?
         .lines()
     {
-        // we deal with this explicitly.
-        if line.trim().is_empty()
-            || line.starts_with("--index-url ")
-            || line.starts_with("--extra-index-url ")
-            || line.starts_with("--find-links ")
-        {
+        if line.trim().is_empty() {
             continue;
         }
 

--- a/rye/src/sync.rs
+++ b/rye/src/sync.rs
@@ -283,8 +283,6 @@ pub fn sync(mut cmd: SyncOptions) -> Result<(), Error> {
                     pip_sync_cmd.env("PIP_VERBOSE", "2");
                 }
 
-                sources.add_as_pip_args(&mut pip_sync_cmd);
-
                 pip_sync_cmd.arg(&target_lockfile);
 
                 if output == CommandOutput::Verbose {

--- a/rye/src/uv.rs
+++ b/rye/src/uv.rs
@@ -329,7 +329,8 @@ impl Uv {
         cmd.arg("--python-version")
             .arg(py_version.format_simple())
             .arg("--output-file")
-            .arg(target);
+            .arg(target)
+            .arg("--emit-index-url");
 
         cmd.arg(source);
 
@@ -508,8 +509,6 @@ impl UvWithVenv {
     pub fn sync(&self, lockfile: &Path) -> Result<(), Error> {
         let mut cmd = self.venv_cmd();
         cmd.arg("pip").arg("sync");
-
-        self.uv.sources.add_as_pip_args(&mut cmd);
 
         let status = cmd
             .arg(lockfile)


### PR DESCRIPTION
Including the sources in the lockfile has the advantage of being able to install the dependencies with `pip` or `uv` directly from the lockfile.

From the code it seems like there was a conscious decision to do it differently, but I'm not sure what the reasoning was back then and whether it's still applicable.
I'm absolutely open for discussions!