### PR TITLE
Add short version add -d for rye add --dev

### DIFF
--- a/rye/src/cli/add.rs
+++ b/rye/src/cli/add.rs
@@ -198,7 +198,7 @@ pub struct Args {
     #[command(flatten)]
     req_extras: ReqExtras,
     /// Add this as dev dependency.
-    #[arg(long)]
+    #[arg(short, long)]
     dev: bool,
     /// Add this as an excluded dependency that will not be installed even if it's a sub dependency.
     #[arg(long, conflicts_with = "dev", conflicts_with = "optional")]


### PR DESCRIPTION
(Feature request) Adding dev-deps is rather common, and it's nice to have a short version for this, so I suggest `-d` for this (long option is `--dev`).

Example:

```
rye add -d pytest
Added pytest>=8.1.1 as dev dependency
```

Survey: pdm uses pdm add -d. Poetry uses poetry add -D (but says it's deprecated, use --group=dev instead.)