### PR TITLE
Flip uv to the default Rye backend

### DIFF
--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -81,9 +81,10 @@ force-rye-managed = false
 # virtual environments.
 global-python = false
 
-# When set to `true` enables experimental support of uv as a replacement
-# for pip-tools. Learn more about uv here: https://github.com/astral-sh/uv
-use-uv = false
+# When set to `true`, Rye will use `uv` for package resolution and installation.
+# Set to `false` to fall back to the `pip-tools` resolver.
+# Learn more about uv here: https://github.com/astral-sh/uv
+use-uv = true
 
 # Enable or disable automatic `sync` after `add` and `remove`.  This defaults
 # to `true` when uv is enabled and `false` otherwise.

--- a/docs/guide/sync.md
+++ b/docs/guide/sync.md
@@ -3,8 +3,8 @@
 Rye supports two systems to manage dependencies:
 [uv](https://github.com/astral-sh/uv) and
 [pip-tools](https://github.com/jazzband/pip-tools).  It currently defaults to
-`pip-tools` but will offer you the option to use `uv` instead.  `uv` will become
-the default choice once it stabilzes as it offers significantly better performance.
+`uv` as it offers significantly better performance, but will offer you the
+option to use `pip-tools` instead.
 
 In order to download dependencies rye creates two "lockfiles" (called
 `requirements.lock` and `requirements-dev.lock`).  These are not real lockfiles

--- a/rye/src/config.rs
+++ b/rye/src/config.rs
@@ -266,7 +266,7 @@ impl Config {
             .get("behavior")
             .and_then(|x| x.get("use-uv"))
             .and_then(|x| x.as_bool())
-            .unwrap_or(false)
+            .unwrap_or(true)
     }
 
     /// Fetches python installations with build info if possible.


### PR DESCRIPTION
## Summary

I think `uv` is now stable enough to serve as the default backend for Rye. Users can explicitly opt-out with, e.g., `rye config --set-bool behavior.use-uv=false`, to fall back to the `pip-tools` backend.

Suggested here: https://twitter.com/mitsuhiko/status/1783853343502160290
