### PR TITLE
Fix Rye not using user-chosen toolchain as default during installation

### DIFF
--- a/rye/src/cli/rye.rs
+++ b/rye/src/cli/rye.rs
@@ -624,12 +624,17 @@ fn perform_install(
         // can fill in the default.
         if !matches!(mode, InstallMode::NoPrompts) {
             if toolchain_path.is_none() {
-                toolchain_version_request = Some(prompt_for_default_toolchain(
+                // Prompt the user for the default toolchain version.
+                let user_version_request = prompt_for_default_toolchain(
                     toolchain_version_request
                         .clone()
                         .unwrap_or(SELF_PYTHON_TARGET_VERSION),
                     config_doc,
-                )?);
+                )?;
+
+                // If the user has selected a toolchain version, we should use that as the default,
+                // unless the `RYE_TOOLCHAIN_VERSION` environment variable is set.
+                toolchain_version_request = toolchain_version_request.or(Some(user_version_request));
             } else {
                 prompt_for_toolchain_later = true;
             }


### PR DESCRIPTION
Fixes https://github.com/astral-sh/rye/issues/1024

Currently:
* When installation calls  `ensure_self_venv_with_toolchain` to bootstrap rye internals it would pass the `toolchain_version_request` variable as the version to install
* If the `RYE_TOOLCHAIN_VERSION` env var is not set, then the value of `toolchain_version_request` remains None
* During installation, `prompt_for_default_toolchain` is called to prompt the user for a version to select, asking the user `"Which version of Python should be used as default toolchain?"`
* This function stores the user's selection in the `config_doc` TOML configuration and returns nothing
* The user's toolchain version selection is thus never passed to the internals bootstrapping call

Changes:
* This fix makes `toolchain_version_request` mutable so it can be updated by the user's input
* Function `prompt_for_default_toolchain` returns the resolved version that the user wants, which may be the input they typed or the default value
* The result is stored in `toolchain_version_request` so it can be used during the internals bootstrapping