### PR TITLE
Fix some spellings

### DIFF
--- a/docs/guide/commands/lock.md
+++ b/docs/guide/commands/lock.md
@@ -3,7 +3,7 @@
 Updates the lockfiles without installing dependencies.  Usually one would use
 the [`sync`](sync.md) command instead which both locks and installs dependencies.
 
-For more information see [Synching and Locking](../sync.md).
+For more information see [Syncing and Locking](../sync.md).
 
 ## Example
 

--- a/docs/guide/commands/sync.md
+++ b/docs/guide/commands/sync.md
@@ -2,7 +2,7 @@
 
 Updates the lockfiles and installs the dependencies into the virtualenv.
 
-For more information see [Synching and Locking](../sync.md).
+For more information see [Syncing and Locking](../sync.md).
 
 ## Example
 

--- a/docs/guide/virtual.md
+++ b/docs/guide/virtual.md
@@ -18,11 +18,11 @@ rye run mkdocs
 ```
 
 This will create a `pyproject.toml` but does not actually declare any python code itself.
-Yet when synching you will end up with mkdocs in your project.
+Yet when syncing you will end up with mkdocs in your project.
 
 ## Behavior Changes
 
-When synching the project itself is never installed into the virtualenv as it's not
+When syncing the project itself is never installed into the virtualenv as it's not
 considered to be a valid package.  Likewise you cannot publish virtual packages to
 PyPI or another index.
 

--- a/rye/src/cli/shim.rs
+++ b/rye/src/cli/shim.rs
@@ -187,7 +187,7 @@ fn get_shim_target(
 ) -> Result<Option<Vec<OsString>>, Error> {
     // if we can find a project, we always look for a local virtualenv first for shims.
     if let Some(pyproject) = pyproject {
-        // However we only allow automatic synching, if we are rye managed.
+        // However we only allow automatic syncing, if we are rye managed.
         if pyproject.rye_managed() {
             let _guard = redirect_to_stderr(true);
             sync(SyncOptions::python_only()).context("sync ahead of shim resolution failed")?;

--- a/rye/src/cli/show.rs
+++ b/rye/src/cli/show.rs
@@ -40,7 +40,7 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
         echo!("venv python: {}", style(&ver).cyan());
         if let Some(actual) = get_current_venv_python_version(&project.venv_path()) {
             if actual != ver {
-                echo!("last synched venv python: {}", style(&actual).red());
+                echo!("last synced venv python: {}", style(&actual).red());
             }
         }
     }

--- a/rye/src/cli/sync.rs
+++ b/rye/src/cli/sync.rs
@@ -34,7 +34,7 @@ pub struct Args {
     /// Update to pre-release versions
     #[arg(long)]
     pre: bool,
-    /// Extras/features to enable when synching the workspace.
+    /// Extras/features to enable when syncing the workspace.
     #[arg(long)]
     features: Vec<String>,
     /// Enables all features.


### PR DESCRIPTION
Similar to https://github.com/astral-sh/rye/pull/165 and https://github.com/astral-sh/rye/pull/167, there are some more instances of synched/synching which should be changed to synced/syncing to make the docs consistent.