### PR TITLE
Bump boostrap ruff to 0.4.4

### DIFF
--- a/rye/src/bootstrap.rs
+++ b/rye/src/bootstrap.rs
@@ -33,7 +33,7 @@ pub const SELF_PYTHON_TARGET_VERSION: PythonVersionRequest = PythonVersionReques
     suffix: None,
 };
 
-const SELF_VERSION: u64 = 18;
+const SELF_VERSION: u64 = 19;
 
 const SELF_REQUIREMENTS: &str = r#"
 build==1.2.1
@@ -52,7 +52,7 @@ twine==4.0.2
 unearth==0.14.0
 urllib3==2.0.7
 virtualenv==20.25.0
-ruff==0.3.0
+ruff==0.4.4
 "#;
 
 static FORCED_TO_UPDATE: AtomicBool = AtomicBool::new(false);

--- a/rye/tests/test_ruff.rs
+++ b/rye/tests/test_ruff.rs
@@ -9,7 +9,10 @@ fn test_lint_and_format() {
     let space = Space::new();
     space.init("my-project");
     space.write(
-        "src/my_project/__init__.py",
+        // `test.py` is used instead of `__init__.py` to make ruff consider it a fixable
+        // issue instead of requiring user intervention.
+        // ref: https://github.com/astral-sh/ruff/pull/11168
+        "src/my_project/test.py",
         r#"import os
 
 def hello():
@@ -24,10 +27,10 @@ def hello():
     success: false
     exit_code: 1
     ----- stdout -----
-    src/my_project/__init__.py:1:8: F401 `os` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
+    src/my_project/__init__.py:1:8: F401 [*] `os` imported but unused
     src/my_project/__init__.py:6:25: E703 [*] Statement ends with an unnecessary semicolon
     Found 2 errors.
-    [*] 1 fixable with the `--fix` option.
+    [*] 2 fixable with the `--fix` option.
 
     ----- stderr -----
     "###);
@@ -39,7 +42,7 @@ def hello():
 
     ----- stderr -----
     "###);
-    assert_snapshot!(space.read_string("src/my_project/__init__.py"), @r###"
+    assert_snapshot!(space.read_string("src/my_project/test.py"), @r###"
 
     def hello():
 
@@ -52,7 +55,7 @@ def hello():
     success: false
     exit_code: 1
     ----- stdout -----
-    Would reformat: src/my_project/__init__.py
+    Would reformat: src/my_project/test.py
     1 file would be reformatted
 
     ----- stderr -----
@@ -65,7 +68,7 @@ def hello():
 
     ----- stderr -----
     "###);
-    assert_snapshot!(space.read_string("src/my_project/__init__.py"), @r###"
+    assert_snapshot!(space.read_string("src/my_project/test.py"), @r###"
     def hello():
         return "Hello World"
     "###);

--- a/rye/tests/test_ruff.rs
+++ b/rye/tests/test_ruff.rs
@@ -27,8 +27,8 @@ def hello():
     success: false
     exit_code: 1
     ----- stdout -----
-    src/my_project/__init__.py:1:8: F401 [*] `os` imported but unused
-    src/my_project/__init__.py:6:25: E703 [*] Statement ends with an unnecessary semicolon
+    src/my_project/test.py:1:8: F401 [*] `os` imported but unused
+    src/my_project/test.py:6:25: E703 [*] Statement ends with an unnecessary semicolon
     Found 2 errors.
     [*] 2 fixable with the `--fix` option.
 

--- a/rye/tests/test_ruff.rs
+++ b/rye/tests/test_ruff.rs
@@ -24,10 +24,10 @@ def hello():
     success: false
     exit_code: 1
     ----- stdout -----
-    src/my_project/__init__.py:1:8: F401 [*] `os` imported but unused
+    src/my_project/__init__.py:1:8: F401 `os` imported but unused; consider removing, adding to `__all__`, or using a redundant alias
     src/my_project/__init__.py:6:25: E703 [*] Statement ends with an unnecessary semicolon
     Found 2 errors.
-    [*] 2 fixable with the `--fix` option.
+    [*] 1 fixable with the `--fix` option.
 
     ----- stderr -----
     "###);

--- a/rye/tests/test_ruff.rs
+++ b/rye/tests/test_ruff.rs
@@ -51,12 +51,13 @@ def hello():
     "###);
 
     // fmt next
+    // Already reformatted file mentioned bellow is `__init__.py`
     rye_cmd_snapshot!(space.rye_cmd().arg("fmt").arg("--check"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
     Would reformat: src/my_project/test.py
-    1 file would be reformatted
+    1 file would be reformatted, 1 file already formatted
 
     ----- stderr -----
     "###);
@@ -64,7 +65,7 @@ def hello():
     success: true
     exit_code: 0
     ----- stdout -----
-    1 file reformatted
+    1 file reformatted, 1 file left unchanged
 
     ----- stderr -----
     "###);


### PR DESCRIPTION
Noticed ruff was a bit old and was missing a lot of rules, leading to a lot of "unused noqa".

I unfortunately dont have the rust knowledge to improve this, but it would be nice if we could update ruff independently of rye and still run it using `rye lint/fmt`.

Thanks for this amazing tool! Gave it a shot today and really really enjoyed playing around with it and testing it out. Currently porting some of my projects to use it!