### PR TITLE
Fix TOML array formatting

### DIFF
--- a/rye/src/utils/toml.rs
+++ b/rye/src/utils/toml.rs
@@ -48,7 +48,9 @@ pub fn reformat_array_multiline(deps: &mut Array) {
                 rv.push_str(comment);
             }
         }
-        rv.push('\n');
+        if !rv.is_empty() || !deps.is_empty() {
+            rv.push('\n');
+        }
         rv
     });
     deps.set_trailing_comma(true);


### PR DESCRIPTION
Closes #1083

A trailing newline is only added if there are dependencies or comments in the array.