### PR TITLE
Write `use-uv = true` in no-prompt mode

### DIFF
--- a/rye/src/cli/rye.rs
+++ b/rye/src/cli/rye.rs
@@ -590,15 +590,15 @@ fn perform_install(
         .get("behavior")
         .and_then(|x| x.get("use-uv"))
         .is_none()
-        && !matches!(mode, InstallMode::NoPrompts)
     {
-        let use_uv = dialoguer::Select::with_theme(tui_theme())
-            .with_prompt("Select the preferred package installer")
-            .item("uv (fast, recommended)")
-            .item("pip-tools (slow, higher compatibility)")
-            .default(0)
-            .interact()?
-            == 0;
+        let use_uv = matches!(mode, InstallMode::NoPrompts)
+            || dialoguer::Select::with_theme(tui_theme())
+                .with_prompt("Select the preferred package installer")
+                .item("uv (fast, recommended)")
+                .item("pip-tools (slow, higher compatibility)")
+                .default(0)
+                .interact()?
+                == 0;
         toml::ensure_table(config_doc, "behavior")["use-uv"] = toml_edit::value(use_uv);
     }
 


### PR DESCRIPTION
## Summary

Ensures that if the user runs in `InstallMode::NoPrompts`, we still write the default (`use-uv = true`) to the configuration file.

Closes https://github.com/astral-sh/rye/issues/1081.

## Test Plan

```
rye on  charlie/def:main
❯ cargo run self install -y
    Finished dev [unoptimized + debuginfo] target(s) in 0.08s
     Running `target/debug/rye self install -y`
Welcome to Rye!

This installer will install rye to /Users/crmarsh/.rye
This path can be changed by exporting the RYE_HOME environment variable.

Details:
  Rye Version: 0.34.0
  Platform: macos (aarch64)

Installed binary to /Users/crmarsh/.rye/shims/rye
Updated self-python installation at /Users/crmarsh/.rye/self

The rye directory /Users/crmarsh/.rye/shims was not detected on PATH.
It is highly recommended that you add it.
Added to PATH.
note: for this to take effect you will need to restart your shell or run this manually:

    source "$HOME/.rye/env"

To make it work with zsh, you might need to add this to your .zprofile:

    source "$HOME/.rye/env"

To make it work with fish, run this once instead:

    set -Ua fish_user_paths "$HOME/.rye/shims"

For more information read https://rye-up.com/guide/installation/

All done!
rye on  charlie/def:main
❯ cat /Users/crmarsh/.rye/config.toml
[behavior]
use-uv = true
global-python = true
```
