### PR TITLE
Enforce `--pre` when auto-syncing

### DIFF
--- a/rye/src/cli/lock.rs
+++ b/rye/src/cli/lock.rs
@@ -37,15 +37,15 @@ pub struct Args {
     /// Attempt to use `keyring` for authentication for index URLs.
     #[arg(long, value_enum, default_value_t)]
     keyring_provider: KeyringProvider,
+    /// Set to true to lock with hashes in the lockfile.
+    #[arg(long)]
+    generate_hashes: bool,
     /// Reset prior lock options.
     #[arg(long)]
     reset: bool,
     /// Use this pyproject.toml file
     #[arg(long, value_name = "PYPROJECT_TOML")]
     pyproject: Option<PathBuf>,
-    /// Set to true to lock with hashes in the lockfile.
-    #[arg(long)]
-    generate_hashes: bool,
 }
 
 pub fn execute(cmd: Args) -> Result<(), Error> {

--- a/rye/src/cli/remove.rs
+++ b/rye/src/cli/remove.rs
@@ -28,15 +28,25 @@ pub struct Args {
     /// Does not run `sync` even if auto-sync is enabled.
     #[arg(long, conflicts_with = "sync")]
     no_sync: bool,
-    /// Attempt to use `keyring` for authentication for index URLs.
-    #[arg(long, value_enum, default_value_t)]
-    keyring_provider: KeyringProvider,
     /// Enables verbose diagnostics.
     #[arg(short, long)]
     verbose: bool,
     /// Turns off all output.
     #[arg(short, long, conflicts_with = "verbose")]
     quiet: bool,
+
+    /// Include pre-releases when automatically syncing the workspace.
+    #[arg(long)]
+    pre: bool,
+    /// Set to `true` to lock with sources in the lockfile when automatically syncing the workspace.
+    #[arg(long)]
+    with_sources: bool,
+    /// Set to `true` to lock with hashes in the lockfile when automatically syncing the workspace.
+    #[arg(long)]
+    generate_hashes: bool,
+    /// Attempt to use `keyring` for authentication for index URLs.
+    #[arg(long, value_enum, default_value_t)]
+    keyring_provider: KeyringProvider,
 }
 
 pub fn execute(cmd: Args) -> Result<(), Error> {
@@ -69,7 +79,14 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
     }
 
     if (Config::current().autosync() && !cmd.no_sync) || cmd.sync {
-        autosync(&pyproject_toml, output, cmd.keyring_provider)?;
+        autosync(
+            &pyproject_toml,
+            output,
+            cmd.pre,
+            cmd.with_sources,
+            cmd.generate_hashes,
+            cmd.keyring_provider,
+        )?;
     }
 
     Ok(())

--- a/rye/src/cli/sync.rs
+++ b/rye/src/cli/sync.rs
@@ -46,15 +46,15 @@ pub struct Args {
     /// Attempt to use `keyring` for authentication for index URLs.
     #[arg(long, value_enum, default_value_t)]
     keyring_provider: KeyringProvider,
+    /// Set to true to lock with hashes in the lockfile.
+    #[arg(long)]
+    generate_hashes: bool,
     /// Use this pyproject.toml file
     #[arg(long, value_name = "PYPROJECT_TOML")]
     pyproject: Option<PathBuf>,
     /// Do not reuse (reset) prior lock options.
     #[arg(long)]
     reset: bool,
-    /// Set to true to lock with hashes in the lockfile.
-    #[arg(long)]
-    generate_hashes: bool,
 }
 
 pub fn execute(cmd: Args) -> Result<(), Error> {

--- a/rye/src/sync.rs
+++ b/rye/src/sync.rs
@@ -319,6 +319,9 @@ pub fn sync(mut cmd: SyncOptions) -> Result<(), Error> {
 pub fn autosync(
     pyproject: &PyProject,
     output: CommandOutput,
+    pre: bool,
+    with_sources: bool,
+    generate_hashes: bool,
     keyring_provider: KeyringProvider,
 ) -> Result<(), Error> {
     sync(SyncOptions {
@@ -327,7 +330,12 @@ pub fn autosync(
         mode: SyncMode::Regular,
         force: false,
         no_lock: false,
-        lock_options: LockOptions::default(),
+        lock_options: LockOptions {
+            pre,
+            with_sources,
+            generate_hashes,
+            ..Default::default()
+        },
         pyproject: Some(pyproject.toml_path().to_path_buf()),
         keyring_provider,
     })


### PR DESCRIPTION
## Summary

We weren't passing `--pre` when auto-syncing after `rye `add`.

Closes https://github.com/astral-sh/rye/issues/1102