### PR TITLE
Move from `rye-up.com` to `rye.astral.sh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ----
 <div align="center">
 
-[![Rye](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/rye/main/artwork/badge.json)](https://rye-up.com)
+[![Rye](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/rye/main/artwork/badge.json)](https://rye.astral.sh)
 [![](https://dcbadge.vercel.app/api/server/drbkcdtSbg?style=flat)](https://discord.gg/drbkcdtSbg)
 
 </div>
@@ -47,21 +47,21 @@ The installation takes just a minute:
 * **Linux and macOS:**
 
     ```
-    curl -sSf https://raw.githubusercontent.com/astral-sh/rye/main/scripts/install.sh | sh
+    curl -sSf https://rye.astral.sh/get | sh
     ```
 
 * **Windows:**
 
     Download and run the installer ([64bit Intel](https://github.com/astral-sh/rye/releases/latest/download/rye-x86_64-windows.exe) or [32bit Intel](https://github.com/astral-sh/rye/releases/latest/download/rye-x86-windows.exe)).
 
-For more details and other options, refer to the [installation instructions](https://rye-up.com/guide/installation/).
+For more details and other options, refer to the [installation instructions](https://rye.astral.sh/guide/installation/).
 
 ## Learn More
 
 Did I spark your interest?
 
-* [Visit the Website](https://rye-up.com/)
-* [Read the Documentation](https://rye-up.com/guide/)
+* [Visit the Website](https://rye.astral.sh/)
+* [Read the Documentation](https://rye.astral.sh/guide/)
 * [Report Problems in the Issue Tracker](https://github.com/astral-sh/rye/issues)
 
 ## More
@@ -70,5 +70,5 @@ Did I spark your interest?
   on GitHub
 * [Discord](https://discord.gg/drbkcdtSbg), for conversations with other developers in text form
 * [Issue Tracker](https://github.com/astral-sh/rye/issues), if you run into bugs or have suggestions
-* [Badges](https://rye-up.com/community/#badges), if you want to show that you use Rye
+* [Badges](https://rye.astral.sh/community/#badges), if you want to show that you use Rye
 * License: MIT

--- a/docs/.includes/curl-to-bash-options.md
+++ b/docs/.includes/curl-to-bash-options.md
@@ -14,5 +14,5 @@ variables:
 This for instance installs a specific version of Rye without asking questions:
 
 ```bash
-curl -sSf https://rye-up.com/get | RYE_VERSION="0.4.0" RYE_INSTALL_OPTION="--yes" bash
+curl -sSf https://rye.astral.sh/get | RYE_VERSION="0.4.0" RYE_INSTALL_OPTION="--yes" bash
 ```

--- a/docs/.includes/quick-install.md
+++ b/docs/.includes/quick-install.md
@@ -4,7 +4,7 @@
     operating system and CPU architecture and install it:
 
     ```bash
-    curl -sSf https://rye-up.com/get | bash
+    curl -sSf https://rye.astral.sh/get | bash
     ```
 
     Alternatively if you don't trust this approach, you can download the latest release
@@ -25,7 +25,7 @@
     operating system and CPU architecture and install it:
 
     ```bash
-    curl -sSf https://rye-up.com/get | bash
+    curl -sSf https://rye.astral.sh/get | bash
     ```
 
     Alternatively if you don't trust this approach, you can download the latest release

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-rye-up.com
+rye.astral.sh

--- a/docs/community.md
+++ b/docs/community.md
@@ -22,21 +22,21 @@ You can also reach out [via Twitter](https://twitter.com/mitsuhiko) or
 Want to show that you are using Rye?  Why not throw a badge into your project's `README.md`:
 
 ```md
-[![Rye](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/rye/main/artwork/badge.json)](https://rye-up.com)
+[![Rye](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/rye/main/artwork/badge.json)](https://rye.astral.sh)
 ```
 
 ... or `README.rst`:
 
 ```rst
 .. image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/rye/main/artwork/badge.json
-    :target: https://rye-up.com
+    :target: https://rye.astral.sh
     :alt: Rye
 ```
 
 ... or, as HTML:
 
 ```html
-<a href="https://rye-up.com"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/rye/main/artwork/badge.json" alt="Rye" style="max-width:100%;"></a>
+<a href="https://rye.astral.sh"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/rye/main/artwork/badge.json" alt="Rye" style="max-width:100%;"></a>
 ```
 
-[![Rye](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/rye/main/artwork/badge.json)](https://rye-up.com)
+[![Rye](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/rye/main/artwork/badge.json)](https://rye.astral.sh)

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -92,7 +92,7 @@ the default one higher priority in the `PATH:
 
 ```
 export PATH="/usr/bin:$PATH"
-curl -sSf https://rye-up.com/get | bash
+curl -sSf https://rye.astral.sh/get | bash
 ```
 
 ## References to Build-Time Paths

--- a/rye/src/bootstrap.rs
+++ b/rye/src/bootstrap.rs
@@ -618,6 +618,6 @@ fn validate_shared_libraries(py: &Path) -> Result<(), Error> {
     }
     bail!(
         "Python installation is unable to run on this machine due to missing libraries.\n\
-        Visit https://rye-up.com/guide/faq/#missing-shared-libraries-on-linux for next steps."
+        Visit https://rye.astral.sh/guide/faq/#missing-shared-libraries-on-linux for next steps."
     );
 }

--- a/rye/src/cli/rye.rs
+++ b/rye/src/cli/rye.rs
@@ -533,7 +533,7 @@ fn perform_install(
         echo!("automatically started the installer for you. For more information");
         echo!(
             "read {}",
-            style("https://rye-up.com/guide/installation/").yellow()
+            style("https://rye.astral.sh/guide/installation/").yellow()
         );
     }
 
@@ -571,7 +571,7 @@ fn perform_install(
         echo!("enable symlinks. You need to enable this before continuing the setup.");
         echo!(
             "Learn more at {}",
-            style("https://rye-up.com/guide/faq/#windows-developer-mode").yellow()
+            style("https://rye.astral.sh/guide/faq/#windows-developer-mode").yellow()
         );
     }
 
@@ -782,7 +782,7 @@ fn add_rye_to_path(mode: &InstallMode, shims: &Path, ask: bool) -> Result<(), Er
                 );
                 echo!();
             }
-            echo!("For more information read https://rye-up.com/guide/installation/");
+            echo!("For more information read https://rye.astral.sh/guide/installation/");
         }
     }
     // On Windows, we add the rye directory to the user's PATH unconditionally.

--- a/rye/src/cli/shim.rs
+++ b/rye/src/cli/shim.rs
@@ -327,7 +327,7 @@ pub fn execute_shim(args: &[OsString]) -> Result<(), Error> {
                     "Target Python binary '{}' not found.\nYou are currently outside of a project. \
                     To resolve this, consider enabling global shims. \
                     Global shims allow for a Rye-managed Python installation.\n\
-                    For more information: https://rye-up.com/guide/shims/#global-shims", shim_name
+                    For more information: https://rye.astral.sh/guide/shims/#global-shims", shim_name
                 );
             }
         } else {

--- a/rye/src/uv.rs
+++ b/rye/src/uv.rs
@@ -311,7 +311,7 @@ impl Uv {
             format!(
                 "unable to create self venv using {}. It might be that \
                       the used Python build is incompatible with this machine. \
-                      For more information see https://rye-up.com/guide/installation/",
+                      For more information see https://rye.astral.sh/guide/installation/",
                 py_bin.display()
             )
         })?;


### PR DESCRIPTION
## Summary

We're having issues with `rye-up.com`. We're trying to recover it but need to work with the registrar. In the interim, I'm going to move the docs and installers to `rye.astral.sh`. When `rye-up.com` is recovered, we can redirect, either from `rye.astral.sh` to `rye-up.com` or vice versa.

Closes #1111.
