### PR TITLE
Fix install instructions on README.md for mac/linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The installation takes just a minute:
 * **Linux and macOS:**
 
     ```
-    curl -sSf https://rye.astral.sh/get | sh
+    curl -sSf https://rye.astral.sh/get | bash
     ```
 
 * **Windows:**


### PR DESCRIPTION
On latest Ubuntu current install instructions result with an error:

```
user@user-laptop:~$ curl -sSf https://rye.astral.sh/get | sh
sh: 2: set: Illegal option -o pipefail
```

While using the instructions on the official website: https://rye.astral.sh/ work as expected.

This PR updates the README.md version to match