### PR TITLE
Add ability to specify option to generate hashes within pyproject.toml

### DIFF
--- a/docs/guide/commands/lock.md
+++ b/docs/guide/commands/lock.md
@@ -30,6 +30,8 @@ Done!
 
 * `--all-features`: Enables all features
 
+* `--generate-hashes`: Set to true to lock with hashes in the lockfile
+
 * `--with-sources`: Set to true to lock with sources in the lockfile
 
 * `--pyproject <PYPROJECT_TOML>`: Use this pyproject.toml file

--- a/docs/guide/commands/lock.md
+++ b/docs/guide/commands/lock.md
@@ -30,7 +30,7 @@ Done!
 
 * `--all-features`: Enables all features
 
-* `--generate-hashes`: Set to true to lock with hashes in the lockfile (if using `uv`)
+* `--generate-hashes`: Set to true to lock with hashes in the lockfile
 
 * `--with-sources`: Set to true to lock with sources in the lockfile
 

--- a/docs/guide/commands/lock.md
+++ b/docs/guide/commands/lock.md
@@ -30,7 +30,7 @@ Done!
 
 * `--all-features`: Enables all features
 
-* `--generate-hashes`: Set to true to lock with hashes in the lockfile
+* `--generate-hashes`: Set to true to lock with hashes in the lockfile (if using `uv`)
 
 * `--with-sources`: Set to true to lock with sources in the lockfile
 

--- a/docs/guide/commands/sync.md
+++ b/docs/guide/commands/sync.md
@@ -53,6 +53,8 @@ To exit the sub shell run `exit`.
 
 * `--all-features`: Enables all features
 
+* `--generate-hashes`: Set to true to lock with hashes in the lockfile
+
 * `--with-sources`: Set to true to lock with sources in the lockfile
 
 * `--pyproject <PYPROJECT_TOML>`: Use this pyproject.toml file

--- a/docs/guide/commands/sync.md
+++ b/docs/guide/commands/sync.md
@@ -53,7 +53,7 @@ To exit the sub shell run `exit`.
 
 * `--all-features`: Enables all features
 
-* `--generate-hashes`: Set to true to lock with hashes in the lockfile (if using `uv`)
+* `--generate-hashes`: Set to true to lock with hashes in the lockfile
 
 * `--with-sources`: Set to true to lock with sources in the lockfile
 

--- a/docs/guide/commands/sync.md
+++ b/docs/guide/commands/sync.md
@@ -53,7 +53,7 @@ To exit the sub shell run `exit`.
 
 * `--all-features`: Enables all features
 
-* `--generate-hashes`: Set to true to lock with hashes in the lockfile
+* `--generate-hashes`: Set to true to lock with hashes in the lockfile (if using `uv`)
 
 * `--with-sources`: Set to true to lock with sources in the lockfile
 

--- a/docs/guide/pyproject.md
+++ b/docs/guide/pyproject.md
@@ -64,7 +64,7 @@ excluded-dependencies = ["cffi"]
 
 +++ 0.35.0
 
-When this flag is enabled (and when using `uv`) all `lock` and `sync` operations in the project or workspace
+When this flag is enabled (and using `uv`) all `lock` and `sync` operations in the project or workspace
 operate as if `--generate-hashes` is passed.  This means that all dependencies in all
 lock files will include a hash.
 

--- a/docs/guide/pyproject.md
+++ b/docs/guide/pyproject.md
@@ -60,7 +60,7 @@ pulled in as indirect dependencies.  These are added here automatically with `ry
 excluded-dependencies = ["cffi"]
 ```
 
-## `tool.rye.lock-generate-hashes`
+## `tool.rye.generate-hashes`
 
 +++ 0.35.0
 
@@ -70,7 +70,7 @@ lock files will include a hash.
 
 ```toml
 [tool.rye]
-lock-generate-hashes = true
+generate-hashes = true
 ```
 
 ## `tool.rye.lock-with-sources`

--- a/docs/guide/pyproject.md
+++ b/docs/guide/pyproject.md
@@ -60,6 +60,19 @@ pulled in as indirect dependencies.  These are added here automatically with `ry
 excluded-dependencies = ["cffi"]
 ```
 
+## `tool.rye.lock-generate-hashes`
+
++++ 0.35.0
+
+When this flag is enabled (and when using uv) all `lock` and `sync` operations in the project or workspace
+operate as if `--generate-hashes` is passed.  This means that all dependencies in all
+lock files will include a hash.
+
+```toml
+[tool.rye]
+lock-generate-hashes = true
+```
+
 ## `tool.rye.lock-with-sources`
 
 +++ 0.18.0

--- a/docs/guide/pyproject.md
+++ b/docs/guide/pyproject.md
@@ -64,7 +64,7 @@ excluded-dependencies = ["cffi"]
 
 +++ 0.35.0
 
-When this flag is enabled (and when using uv) all `lock` and `sync` operations in the project or workspace
+When this flag is enabled (and when using `uv`) all `lock` and `sync` operations in the project or workspace
 operate as if `--generate-hashes` is passed.  This means that all dependencies in all
 lock files will include a hash.
 

--- a/docs/guide/pyproject.md
+++ b/docs/guide/pyproject.md
@@ -64,7 +64,7 @@ excluded-dependencies = ["cffi"]
 
 +++ 0.35.0
 
-When this flag is enabled (and using `uv`) all `lock` and `sync` operations in the project or workspace
+When this flag is enabled all `lock` and `sync` operations in the project or workspace
 operate as if `--generate-hashes` is passed.  This means that all dependencies in all
 lock files will include a hash.
 

--- a/rye/src/pyproject.rs
+++ b/rye/src/pyproject.rs
@@ -535,6 +535,11 @@ impl Workspace {
         is_rye_managed(&self.doc)
     }
 
+    /// Should requirements.txt based locking include generating hashes?
+    pub fn lock_generate_hashes(&self) -> bool {
+        lock_generate_hashes(&self.doc)
+    }
+
     /// Should requirements.txt based locking include a find-links reference?
     pub fn lock_with_sources(&self) -> bool {
         lock_with_sources(&self.doc)
@@ -1006,6 +1011,14 @@ impl PyProject {
             .unwrap_or(false)
     }
 
+    /// Should requirements.txt based locking include generating hashes?
+    pub fn lock_generate_hashes(&self) -> bool {
+        match self.workspace {
+            Some(ref workspace) => workspace.lock_generate_hashes(),
+            None => lock_generate_hashes(&self.doc),
+        }
+    }
+
     /// Should requirements.txt based locking include a find-links reference?
     pub fn lock_with_sources(&self) -> bool {
         match self.workspace {
@@ -1276,6 +1289,14 @@ fn is_rye_managed(doc: &DocumentMut) -> bool {
     doc.get("tool")
         .and_then(|x| x.get("rye"))
         .and_then(|x| x.get("managed"))
+        .and_then(|x| x.as_bool())
+        .unwrap_or(false)
+}
+
+fn lock_generate_hashes(doc: &DocumentMut) -> bool {
+    doc.get("tool")
+        .and_then(|x| x.get("rye"))
+        .and_then(|x| x.get("lock-generate-hashes"))
         .and_then(|x| x.as_bool())
         .unwrap_or(false)
 }

--- a/rye/src/pyproject.rs
+++ b/rye/src/pyproject.rs
@@ -536,8 +536,8 @@ impl Workspace {
     }
 
     /// Should requirements.txt based locking include generating hashes?
-    pub fn lock_generate_hashes(&self) -> bool {
-        lock_generate_hashes(&self.doc)
+    pub fn generate_hashes(&self) -> bool {
+        generate_hashes(&self.doc)
     }
 
     /// Should requirements.txt based locking include a find-links reference?
@@ -1011,15 +1011,15 @@ impl PyProject {
             .unwrap_or(false)
     }
 
-    /// Should requirements.txt based locking include generating hashes?
-    pub fn lock_generate_hashes(&self) -> bool {
+    /// Should requirements.txt-based locking include generating hashes?
+    pub fn generate_hashes(&self) -> bool {
         match self.workspace {
-            Some(ref workspace) => workspace.lock_generate_hashes(),
-            None => lock_generate_hashes(&self.doc),
+            Some(ref workspace) => workspace.generate_hashes(),
+            None => generate_hashes(&self.doc),
         }
     }
 
-    /// Should requirements.txt based locking include a find-links reference?
+    /// Should requirements.txt-based locking include a find-links reference?
     pub fn lock_with_sources(&self) -> bool {
         match self.workspace {
             Some(ref workspace) => workspace.lock_with_sources(),
@@ -1293,10 +1293,10 @@ fn is_rye_managed(doc: &DocumentMut) -> bool {
         .unwrap_or(false)
 }
 
-fn lock_generate_hashes(doc: &DocumentMut) -> bool {
+fn generate_hashes(doc: &DocumentMut) -> bool {
     doc.get("tool")
         .and_then(|x| x.get("rye"))
-        .and_then(|x| x.get("lock-generate-hashes"))
+        .and_then(|x| x.get("generate-hashes"))
         .and_then(|x| x.as_bool())
         .unwrap_or(false)
 }

--- a/rye/src/sync.rs
+++ b/rye/src/sync.rs
@@ -106,7 +106,7 @@ pub fn sync(mut cmd: SyncOptions) -> Result<(), Error> {
     }
 
     // Turn on generate_hashes if the project demands it.
-    if pyproject.lock_generate_hashes() {
+    if pyproject.generate_hashes() {
         cmd.lock_options.generate_hashes = true;
     }
 

--- a/rye/src/sync.rs
+++ b/rye/src/sync.rs
@@ -105,6 +105,11 @@ pub fn sync(mut cmd: SyncOptions) -> Result<(), Error> {
         bail!("cannot sync or generate lockfile: package needs 'pyproject.toml'");
     }
 
+    // Turn on generate_hashes if the project demands it.
+    if pyproject.lock_generate_hashes() {
+        cmd.lock_options.generate_hashes = true;
+    }
+
     // Turn on locking with sources if the project demands it.
     if pyproject.lock_with_sources() {
         cmd.lock_options.with_sources = true;


### PR DESCRIPTION
Please note: I haven't written any Rust before, but just wanted this feature hence thought I'd try submitting a PR for this. I've essentially tried to mimic the code regarding the `--with-sources` feature. I'm not sure how to compile and test locally (so welcome any info on this - and if helpful I would be happy to test this locally and get back to confirm if this works).

All thoughts/help/feedback etc. very welcome, and no worries if this feature is not useful. 

- Adds ability to specify option to generate hashes via the pyproject.toml (similar to https://rye.astral.sh/guide/pyproject/#toolryelock-with-sources).
- Updates doc regarding the `--generate-hashes` option too.
- Added [`+++ 0.35.0`](https://github.com/astral-sh/rye/pull/1129/files#diff-8ea7c706930a01df775defe815afe2478a41699e0ac0b99d7b069c0fe0d9f45fR65) to the doc in case it gets merged for this version, but feel free to amend as appropriate.

Thanks!