### PR TITLE
Imply not using cache when invoking sync --update-all

### DIFF
--- a/rye/src/uv.rs
+++ b/rye/src/uv.rs
@@ -66,7 +66,7 @@ impl UvCompileOptions {
 
         match self.upgrade {
             UvPackageUpgrade::All => {
-                cmd.arg("--upgrade");
+                cmd.arg("--upgrade").arg("--no-cache");
             }
             UvPackageUpgrade::Packages(ref pkgs) => {
                 for pkg in pkgs {

--- a/rye/src/uv.rs
+++ b/rye/src/uv.rs
@@ -66,7 +66,7 @@ impl UvCompileOptions {
 
         match self.upgrade {
             UvPackageUpgrade::All => {
-                cmd.arg("--upgrade").arg("--no-cache");
+                cmd.arg("--upgrade").arg("--refresh");
             }
             UvPackageUpgrade::Packages(ref pkgs) => {
                 for pkg in pkgs {


### PR DESCRIPTION
Hi! This is an attempt to fix https://github.com/astral-sh/rye/issues/1128 by basically passing the `--no-cache`  to `uv` command on lockfile generation.
This should work exactly the same (https://github.com/astral-sh/uv/blob/8ae5c2aee3fa22ac7d11337688e4c1bee3748fe3/crates/uv-cache/src/cli.rs#L17) as adding `UV_NO_CACHE=true` as environment variable as the issue author tried in order to get the desired behaviour.