### PR TITLE
Update Docs Description for Download Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The installation takes just a minute:
 
 * **Windows:**
 
-    Download and run the installer ([64bit Intel](https://github.com/astral-sh/rye/releases/latest/download/rye-x86_64-windows.exe) or [32bit Intel](https://github.com/astral-sh/rye/releases/latest/download/rye-x86-windows.exe)).
+    Download and run the installer ([64-bit (x86-64)](https://github.com/astral-sh/rye/releases/latest/download/rye-x86_64-windows.exe) or [32-bit (x86)](https://github.com/astral-sh/rye/releases/latest/download/rye-x86-windows.exe)).
 
 For more details and other options, refer to the [installation instructions](https://rye.astral.sh/guide/installation/).
 

--- a/docs/.includes/quick-install.md
+++ b/docs/.includes/quick-install.md
@@ -10,8 +10,8 @@
     Alternatively if you don't trust this approach, you can download the latest release
     binary.  On first run it will install itself.
 
-    * [rye-x86_64-linux.gz](https://github.com/astral-sh/rye/releases/latest/download/rye-x86_64-linux.gz) for 64bit Intel computers
-    * [rye-aarch64-linux.gz](https://github.com/astral-sh/rye/releases/latest/download/rye-aarch64-linux.gz) for 64bit ARM computers
+    * [rye-x86_64-linux.gz](https://github.com/astral-sh/rye/releases/latest/download/rye-x86_64-linux.gz) Intel/AMD (x86-64).
+    * [rye-aarch64-linux.gz](https://github.com/astral-sh/rye/releases/latest/download/rye-aarch64-linux.gz) for ARM64.
 
     ```bash
     gunzip rye-x86_64-linux.gz
@@ -31,8 +31,8 @@
     Alternatively if you don't trust this approach, you can download the latest release
     binary.  On first run it will install itself.
 
-    * [rye-aarch64-macos.gz](https://github.com/astral-sh/rye/releases/latest/download/rye-aarch64-macos.gz) for M1/M2 Macs
-    * [rye-x86_64-macos.gz](https://github.com/astral-sh/rye/releases/latest/download/rye-x86_64-macos.gz) for Intel Macs
+    * [rye-aarch64-macos.gz](https://github.com/astral-sh/rye/releases/latest/download/rye-aarch64-macos.gz) for Apple Silicon (M1/M2/M3) (ARM64).
+    * [rye-x86_64-macos.gz](https://github.com/astral-sh/rye/releases/latest/download/rye-x86_64-macos.gz) for Intel processors (x86-64).
 
     ```bash
     gunzip rye-aarch64-macos.gz
@@ -47,8 +47,8 @@
     to have "Developer Mode" activated when using Rye and before starting the
     installation.  [Learn more](../guide/faq.md).
 
-    * [rye-x86_64-windows.exe](https://github.com/astral-sh/rye/releases/latest/download/rye-x86_64-windows.exe) for 64bit Intel Windows
-    * [rye-x86-windows.exe](https://github.com/astral-sh/rye/releases/latest/download/rye-x86-windows.exe) for 32bit Intel Windows
+    * [rye-x86_64-windows.exe](https://github.com/astral-sh/rye/releases/latest/download/rye-x86_64-windows.exe) for 64-bit (x86-64).
+    * [rye-x86-windows.exe](https://github.com/astral-sh/rye/releases/latest/download/rye-x86-windows.exe) for 32-bit (x86).
 
     !!!Note
     


### PR DESCRIPTION
Was just downloading Rye to try it out and got a bit annoyed by the confusing download links (like `x64 Intel Windows`  - I have an AMD CPU, and it obviously doesn't matter), so I updated them to more standard terms, although there are several options to update them to, so feel free to ask for / make changes).

I also think it might be a good idea to consider dropping the Windows x86 (32-bit) builds, as Windows 11 doesn't even support x86, and Windows 10 EOL is next year (plus, I doubt there are many Windows 10 users using the 32-bit version. Especially developers), and it just confuses newcomers with an additional option to pick from.