### PR TITLE
Publish: Allow empty token, so twine uses keyring

### DIFF
--- a/rye/src/cli/publish.rs
+++ b/rye/src/cli/publish.rs
@@ -252,7 +252,6 @@ fn secret_from_token(
         let maybe_encrypted = maybe_encrypt(&secret, yes)?;
         let maybe_encoded = maybe_encode(&secret, &maybe_encrypted);
         repo_credentials["token"] = Item::Value(maybe_encoded.expose_secret().into());
-
         Ok(Some(secret))
     }
 }


### PR DESCRIPTION
Similar in spirit to https://github.com/astral-sh/rye/pull/759, but less ambitious.

This just makes rye accept empty-string `token` values. In such a case, rye just doesn't pass a `--password` value onto `twine`. This is valid from twine's perspective; in this case twine will fall back to using [its keyring support](https://twine.readthedocs.io/en/stable/#keyring-support).