### PR TITLE
fix verify-ssl option parsing problem

### DIFF
--- a/rye/src/pyproject.rs
+++ b/rye/src/pyproject.rs
@@ -159,7 +159,8 @@ impl SourceRef {
             .map(|x| x.to_string())
             .ok_or_else(|| anyhow!("expected source.url"))?;
         let verify_ssl = source
-            .get("verify-ssl")
+            .get("verify_ssl")
+            .or_else(|| source.get("verify-ssl"))
             .and_then(|x| x.as_bool())
             .unwrap_or(true);
         let username = source

--- a/rye/src/pyproject.rs
+++ b/rye/src/pyproject.rs
@@ -159,7 +159,7 @@ impl SourceRef {
             .map(|x| x.to_string())
             .ok_or_else(|| anyhow!("expected source.url"))?;
         let verify_ssl = source
-            .get("verify_ssl")
+            .get("verify-ssl")
             .and_then(|x| x.as_bool())
             .unwrap_or(true);
         let username = source


### PR DESCRIPTION
https://github.com/astral-sh/rye/blob/main/docs/guide/sources.md?plain=1#L131

The documentation refers to verify-ssl to avoid ssl verification, but during parsing, it refers to verify_ssl. This PR will allow the installation of packages from non-SSL PyPI repositories.
If the documentation needs to be corrected instead of the source code, please let me know, and I will commit the changes.

