### PR TITLE
Remove redundant alias information from CLI

### DIFF
--- a/rye/src/cli/fetch.rs
+++ b/rye/src/cli/fetch.rs
@@ -10,7 +10,7 @@ use crate::pyproject::PyProject;
 use crate::sources::py::PythonVersionRequest;
 use crate::utils::CommandOutput;
 
-/// Fetches a Python interpreter for the local machine. This is an alias of `rye toolchain fetch`.
+/// Fetches a Python interpreter for the local machine
 #[derive(Parser, Debug)]
 pub struct Args {
     /// The version of Python to fetch.

--- a/rye/src/cli/fetch.rs
+++ b/rye/src/cli/fetch.rs
@@ -10,7 +10,7 @@ use crate::pyproject::PyProject;
 use crate::sources::py::PythonVersionRequest;
 use crate::utils::CommandOutput;
 
-/// Fetches a Python interpreter for the local machine
+/// Fetches a Python interpreter for the local machine.
 #[derive(Parser, Debug)]
 pub struct Args {
     /// The version of Python to fetch.

--- a/rye/src/cli/install.rs
+++ b/rye/src/cli/install.rs
@@ -11,7 +11,7 @@ use crate::lock::KeyringProvider;
 use crate::sources::py::PythonVersionRequest;
 use crate::utils::CommandOutput;
 
-/// Installs a package as global tool. This is an alias of `rye tools install`.
+/// Installs a package as global tool
 #[derive(Parser, Debug)]
 pub struct Args {
     /// The name of the package to install.

--- a/rye/src/cli/install.rs
+++ b/rye/src/cli/install.rs
@@ -11,7 +11,7 @@ use crate::lock::KeyringProvider;
 use crate::sources::py::PythonVersionRequest;
 use crate::utils::CommandOutput;
 
-/// Installs a package as global tool
+/// Installs a package as global tool.
 #[derive(Parser, Debug)]
 pub struct Args {
     /// The name of the package to install.

--- a/rye/src/cli/uninstall.rs
+++ b/rye/src/cli/uninstall.rs
@@ -4,10 +4,10 @@ use clap::Parser;
 use crate::installer::uninstall;
 use crate::utils::CommandOutput;
 
-/// Uninstalls a global tool
+/// Uninstalls a global tool.
 #[derive(Parser, Debug)]
 pub struct Args {
-    /// The package to uninstall
+    /// The package to uninstall.
     name: String,
     /// Enables verbose diagnostics.
     #[arg(short, long)]

--- a/rye/src/cli/uninstall.rs
+++ b/rye/src/cli/uninstall.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use crate::installer::uninstall;
 use crate::utils::CommandOutput;
 
-/// Uninstalls a global tool. This is an alias of `rye tools uninstall`.
+/// Uninstalls a global tool
 #[derive(Parser, Debug)]
 pub struct Args {
     /// The package to uninstall


### PR DESCRIPTION
Remove redundant information about `toolchain fetch` being an alias of `toolchain fetch`.

<img width="483" alt="image" src="https://github.com/user-attachments/assets/f20fe66e-124f-4750-87bf-85d862041861">
