### PR TITLE
Respect `.python-version` in Rye builds

### DIFF
--- a/rye/src/bootstrap.rs
+++ b/rye/src/bootstrap.rs
@@ -35,7 +35,7 @@ pub const SELF_PYTHON_TARGET_VERSION: PythonVersionRequest = PythonVersionReques
 
 const SELF_VERSION: u64 = 20;
 
-const SELF_REQUIREMENTS: &str = r#"
+pub const SELF_REQUIREMENTS: &str = r#"
 build==1.2.1
 certifi==2024.2.2
 charset-normalizer==3.3.2

--- a/rye/src/cli/build.rs
+++ b/rye/src/cli/build.rs
@@ -2,12 +2,14 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
-use anyhow::{anyhow, bail, Error};
+use anyhow::{anyhow, bail, Context, Error};
 use clap::Parser;
 use console::style;
 
-use crate::bootstrap::ensure_self_venv;
+use crate::bootstrap::{fetch, FetchOptions};
 use crate::config::Config;
+
+use crate::platform::get_toolchain_python_bin;
 use crate::pyproject::{locate_projects, PyProject};
 use crate::utils::{get_venv_python_bin, prepend_path_to_path_env, CommandOutput, IoPathContext};
 use crate::uv::UvBuilder;
@@ -46,8 +48,8 @@ pub struct Args {
 
 pub fn execute(cmd: Args) -> Result<(), Error> {
     let output = CommandOutput::from_quiet_and_verbose(cmd.quiet, cmd.verbose);
-    let self_venv = ensure_self_venv(output)?;
     let project = PyProject::load_or_discover(cmd.pyproject.as_deref())?;
+    let py_ver = project.venv_python_version()?;
 
     let out = match cmd.out {
         Some(path) => path,
@@ -71,6 +73,27 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
         warn!("skipping build, all projects are virtual");
         return Ok(());
     }
+
+    // Make sure we have a compatible Python version.
+    let py_ver = fetch(&py_ver.into(), FetchOptions::with_output(output))
+        .context("failed fetching toolchain ahead of sync")?;
+    echo!(if output, "Python version: {}", style(&py_ver).cyan());
+    let py_bin = get_toolchain_python_bin(&py_ver)?;
+
+    // Create a virtual environment in which to perform the builds.
+    let uv = UvBuilder::new()
+        .with_output(CommandOutput::Quiet)
+        .ensure_exists()?;
+    let venv_dir = tempfile::tempdir().context("failed to create temporary directory")?;
+    let uv_venv = uv
+        .venv(venv_dir.path(), &py_bin, &py_ver, None)
+        .context("failed to create build environment")?;
+    uv_venv.write_marker()?;
+    uv_venv.bootstrap()?;
+
+    // Respect the output level for the actual builds.
+    let uv = uv.with_output(output);
+
     for project in projects {
         // skip over virtual packages on build
         if project.is_virtual() {
@@ -83,7 +106,7 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
             style(project.normalized_name()?).cyan()
         );
 
-        let mut build_cmd = Command::new(get_venv_python_bin(&self_venv));
+        let mut build_cmd = Command::new(get_venv_python_bin(venv_dir.path()));
         build_cmd
             .arg("-mbuild")
             .env("NO_COLOR", "1")
@@ -92,8 +115,6 @@ pub fn execute(cmd: Args) -> Result<(), Error> {
             .arg(&*project.root_path());
 
         if use_uv {
-            // we need to ensure uv is available to use without installing it into self_venv
-            let uv = UvBuilder::new().with_output(output).ensure_exists()?;
             let uv_dir = uv
                 .uv_bin()
                 .parent()

--- a/rye/src/uv.rs
+++ b/rye/src/uv.rs
@@ -1,5 +1,6 @@
-use crate::bootstrap::download_url;
+use crate::bootstrap::{download_url, SELF_REQUIREMENTS};
 use crate::lock::{make_project_root_fragment, KeyringProvider};
+use crate::piptools::LATEST_PIP;
 use crate::platform::get_app_dir;
 use crate::pyproject::{read_venv_marker, write_venv_marker, ExpandedSources};
 use crate::sources::py::PythonVersion;
@@ -267,6 +268,12 @@ impl Uv {
         Ok(())
     }
 
+    /// Set the [`CommandOutput`] level for subsequent invocations of uv.
+    #[must_use]
+    pub fn with_output(self, output: CommandOutput) -> Self {
+        Self { output, ..self }
+    }
+
     /// Returns a new command with the uv binary as the command to run.
     /// The command will have the correct proxy settings and verbosity level based on CommandOutput.
     pub fn cmd(&self) -> Command {
@@ -443,6 +450,12 @@ impl UvWithVenv {
     pub fn update(&self, pip_version: &str, requirements: &str) -> Result<(), Error> {
         self.update_pip(pip_version)?;
         self.update_requirements(requirements)?;
+        Ok(())
+    }
+
+    /// Install the bootstrap requirements in the venv.
+    pub fn bootstrap(&self) -> Result<(), Error> {
+        self.update(LATEST_PIP, SELF_REQUIREMENTS)?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Today, `rye build` uses the bootstrapped (or "self") environment, which means built wheels reflect the version from the bootstrapped environment, rather than the user's Python preference.

This PR changes `build` to instead create an ephemeral build environment based on the requested Python version (then install and run `build` in that environment).

Creating and populating that ephemeral build environment is extremely fast with uv; there's virtually no overhead.

Closes https://github.com/astral-sh/rye/issues/1152.
Closes https://github.com/astral-sh/rye/issues/1248.

## Test Plan

- Ran `../rye/target/debug/rye build` from a directory with `.python-version` of `3.11`.
- Verified that Python 3.11 was used.
