### PR TITLE
Use case-insensitive comparison for detecting `rye.exe`

### DIFF
--- a/rye/src/cli/shim.rs
+++ b/rye/src/cli/shim.rs
@@ -31,7 +31,7 @@ fn detect_shim(args: &[OsString]) -> Option<String> {
 
     // rye is itself placed in the shims folder, so it must not
     // detect itself.
-    if shim_name == "rye" || shim_name == "rye.exe" {
+    if shim_name.eq_ignore_ascii_case("rye") || shim_name.eq_ignore_ascii_case("rye.exe") {
         return None;
     }
 


### PR DESCRIPTION
## Summary

This check can be subtly incorrect on case-insensitive filesystems (e.g., NTFS). Seems easiest to just make the whole comparison case-insensitive.

Closes https://github.com/astral-sh/rye/issues/1284.
