### PR TITLE
Allow workspaces to specify member search root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1661,6 +1661,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "reword"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1832,6 +1838,7 @@ dependencies = [
  "pep508_rs",
  "python-pkginfo",
  "regex",
+ "relative-path",
  "same-file",
  "self-replace",
  "serde",

--- a/docs/guide/workspaces.md
+++ b/docs/guide/workspaces.md
@@ -31,6 +31,16 @@ members = ["myname-*"]
 
 For more information on that see [Virtual Packages](../virtual/).
 
+Workspaces can optionally be configured to reference members from root directories.
+This can be used with more complex project structures to store `pyproject.toml` files
+for workspaces separately from the source tree.
+
+```toml
+[tool.rye.workspace]
+root = ".."
+members = ["myname-*"]
+```
+
 ## Syncing
 
 In a workspace it does not matter which project you are working with, the entire

--- a/rye/Cargo.toml
+++ b/rye/Cargo.toml
@@ -55,6 +55,7 @@ python-pkginfo = { version = "0.6.0", features = ["serde"] }
 home = "0.5.9"
 ctrlc = "3.4.2"
 dotenvy = "0.15.7"
+relative-path = "1.9.3"
 
 [target."cfg(unix)".dependencies]
 xattr = "1.3.1"

--- a/rye/src/pyproject.rs
+++ b/rye/src/pyproject.rs
@@ -631,6 +631,16 @@ impl PyProject {
             workspace = Workspace::discover_from_path(root).map(Arc::new);
         }
 
+        if let Some(ref workspace) = workspace {
+            if !workspace.is_member(root) {
+                bail!(
+                    "project {} is not part of pyproject workspace {}",
+                    filename.display(),
+                    workspace.path().display()
+                );
+            }
+        }
+
         let basename = match filename.file_name() {
             Some(name) => name.to_os_string(),
             None => bail!("project {} has no file name", root.display()),

--- a/rye/src/pyproject.rs
+++ b/rye/src/pyproject.rs
@@ -29,6 +29,7 @@ use pep440_rs::{Operator, Version, VersionSpecifiers};
 use pep508_rs::Requirement;
 use python_pkginfo::Metadata;
 use regex::Regex;
+use relative_path::RelativePathBuf;
 use serde::Serialize;
 use toml_edit::{Array, DocumentMut, Formatted, Item, Table, TableLike, Value};
 use url::Url;
@@ -372,6 +373,7 @@ impl fmt::Display for Script {
 #[derive(Debug)]
 pub struct Workspace {
     root: PathBuf,
+    search_root: PathBuf,
     doc: DocumentMut,
     members: Option<Vec<String>>,
 }
@@ -385,6 +387,13 @@ impl Workspace {
             .and_then(|x| x.as_table_like())
             .map(|workspace| Workspace {
                 root: path.to_path_buf(),
+                search_root: workspace
+                    .get("root")
+                    .and_then(|x| x.as_str())
+                    .map_or(RelativePathBuf::from("."), RelativePathBuf::from)
+                    .to_path(path)
+                    .canonicalize()
+                    .unwrap_or(path.into()),
                 doc: doc.clone(),
                 members: workspace
                     .get("members")
@@ -430,7 +439,9 @@ impl Workspace {
 
     /// Checks if a project is a member of the declared workspace.
     pub fn is_member(&self, path: &Path) -> bool {
-        if let Ok(relative) = path.strip_prefix(&self.root) {
+        if path.eq(&self.root) {
+            true
+        } else if let Ok(relative) = path.strip_prefix(&self.search_root) {
             if relative == Path::new("") {
                 true
             } else {
@@ -469,7 +480,7 @@ impl Workspace {
     pub fn iter_projects<'a>(
         self: &'a Arc<Self>,
     ) -> impl Iterator<Item = Result<PyProject, Error>> + 'a {
-        walkdir::WalkDir::new(&self.root)
+        walkdir::WalkDir::new(&self.search_root)
             .into_iter()
             .filter_entry(|entry| {
                 !(entry.file_type().is_dir() && skip_recurse_into(entry.file_name()))
@@ -516,14 +527,14 @@ impl Workspace {
     /// That is the Python version that appears as lower bound in the
     /// pyproject toml.
     pub fn target_python_version(&self) -> Option<PythonVersionRequest> {
-        resolve_target_python_version(&self.doc, &self.root, &self.venv_path())
+        resolve_target_python_version(&self.doc, &self.search_root, &self.venv_path())
     }
 
     /// Returns the project's intended venv python version.
     ///
     /// This is the python version that should be used for virtualenvs.
     pub fn venv_python_version(&self) -> Result<PythonVersion, Error> {
-        resolve_intended_venv_python_version(&self.doc, &self.root)
+        resolve_intended_venv_python_version(&self.doc, &self.search_root)
     }
 
     /// Returns a list of index URLs that should be considered.
@@ -618,16 +629,6 @@ impl PyProject {
 
         if workspace.is_none() {
             workspace = Workspace::discover_from_path(root).map(Arc::new);
-        }
-
-        if let Some(ref workspace) = workspace {
-            if !workspace.is_member(root) {
-                bail!(
-                    "project {} is not part of pyproject workspace {}",
-                    filename.display(),
-                    workspace.path().display()
-                );
-            }
         }
 
         let basename = match filename.file_name() {

--- a/rye/tests/test_test.rs
+++ b/rye/tests/test_test.rs
@@ -37,7 +37,6 @@ fn test_basic_tool_behavior() {
         deps.push("pytest>=7.0.0");
         deps.push("colorama==0.4.6");
         let mut workspace_members = Array::new();
-        workspace_members.push(".");
         workspace_members.push("child-dep");
         doc["tool"]["rye"]["dev-dependencies"] = value(deps);
         doc["tool"]["rye"]["workspace"]["members"] = value(workspace_members);


### PR DESCRIPTION
There are a few related issues and open PRs https://github.com/astral-sh/rye/issues/856, https://github.com/astral-sh/rye/pull/1074, https://github.com/astral-sh/rye/pull/1023. 

For my use case, I think current limitation with workspace can be boiled down to this example. Given a "flat" monorepo structure like so. If `foo` and `bar` both depend on `utils`, but otherwise have conflicting dependencies, there is no way to configure a workspace properly in the root `pyproject.toml `.
```
libs
├── bar
│   ├── pyproject.toml
│   └── src
├── foo
│   ├── pyproject.toml
│   └── src
└── utils
    ├── pyproject.toml
    └── src
pyproject.toml
```
This change would allow the following structure, or other approaches with multiple workspaces per repo.
```
libs
├── bar
│   ├── pyproject.toml
│   └── src
├── foo
│   ├── pyproject.toml
│   └── src
└── utils
    ├── pyproject.toml
    └── src
workspaces
├── bar
│   └── pyproject.toml
└── foo
    └── pyproject.toml
```

My rust is quite rusty, sorry in advance.