### PR TITLE
Fix documentation for readline license

### DIFF
--- a/docs/guide/toolchains/cpython.md
+++ b/docs/guide/toolchains/cpython.md
@@ -28,7 +28,7 @@ different from a regular Python build.
 
 The following changes to a regular Python versions you should be aware of:
 
-* `libedit` instead of `readline`: unfortunately `readline` is GPL2 licensed
+* `libedit` instead of `readline`: unfortunately `readline` is GPLv3 licensed
   and this is a hazard for redistributions.  As such, the portable Python
   builds link against the more freely licensed `libedit` instead.
 


### PR DESCRIPTION
NITS: I fixed the license for readline in the documentation to GPLv3.

cf. https://tiswww.case.edu/php/chet/readline/rltop.html

> Readline is free software, distributed under the terms of the [GNU General Public License, version 3](http://www.gnu.org/licenses/gpl.html).

cf. https://gregoryszorc.com/docs/python-build-standalone/main/running.html#licensing

> Most licenses are fairly permissive. Notable exceptions to this are GDBM and readline, which are both licensed under GPL Version 3.