### PR TITLE
Set environment variables to provide context to scripts

### DIFF
--- a/rye/src/cli/run.rs
+++ b/rye/src/cli/run.rs
@@ -62,8 +62,15 @@ fn invoke_script(
 ) -> Result<ExitStatus, Error> {
     let venv_bin = pyproject.venv_bin_path();
     let mut env_overrides = None;
+    let name = args[0].to_string_lossy();
 
-    match pyproject.get_script_cmd(&args[0].to_string_lossy()) {
+    std::env::set_var("WORKING_DIR", std::env::current_dir()?);
+    std::env::set_var("RYE", std::env::current_exe()?);
+    std::env::set_var("RYE_RUN_CMD", &*name);
+    std::env::set_var("PROJECT_ROOT", &*pyproject.root_path());
+    std::env::set_var("WORKSPACE_ROOT", &*pyproject.workspace_path());
+
+    match pyproject.get_script_cmd(&name) {
         Some(Script::Call(entry, env_vars, env_file)) => {
             let py = OsString::from(get_venv_python_bin(&pyproject.venv_path()));
             env_overrides = Some(load_env_vars(pyproject, env_file, env_vars)?);


### PR DESCRIPTION
Sets the environment variables listed below to allow scripts to have some context when determining what to do and where to do it. This also provides some information to create Python packages for experimenting with some suggested `rye run` features.

Environment Variables:

 * **WORKING_DIR**: Initial working directory. Useful in env files
 * **RYE**: Full path of the rye executable running the command. Useful for scripts that call rye
 * **RYE_RUN_CMD**: Name of the command being run. Helpful for commands that run the same script to differentiate the command or for scripts to read the command entry from pyproject.toml
 * **PROJECT_ROOT**: Full path of the directory containing pyproject.toml. Useful for scripts to do work relative to the project root or that need to read the pyproject.toml.
 * **WORKSPACE_ROOT**: Full path of the workspace. Similar to PROJECT_ROOT, but for the workspace

The variables are set on the process before processing env files so they may be used in those files.