### PR TITLE
Update docker.md to fix error when building with  default Dockerfile config

### DIFF
--- a/docs/guide/docker.md
+++ b/docs/guide/docker.md
@@ -21,6 +21,11 @@ This guide requires some familiarity with Docker and Dockerfiles.
     
     WORKDIR /app
     COPY requirements.lock ./
+    # When using pip to install requirements.lock, it uses the line `-e file:.` to
+    # determine where to find the content when installing package. However, here we
+    # are only installing the dependencies, so this will give an error when we run it.
+    # Thus, we remove it from the file
+    RUN sed -i 's/-e file:\.//g' requirements.lock
     RUN PYTHONDONTWRITEBYTECODE=1 pip install --no-cache-dir -r requirements.lock
     
     COPY src .


### PR DESCRIPTION
Using the default Dockerfile as shown in the documentation results in the following error:

```
> [4/5] RUN PYTHONDONTWRITEBYTECODE=1 pip install -e . --no-cache-dir:                                    
1.350 Obtaining file:///app                                                                                
1.498 ERROR: file:///app does not appear to be a Python project: neither 'setup.py' nor 'pyproject.toml' found.
```

As shown in the comment:

> When using pip to install requirements.lock, it uses the line `-e file:.` to determine where to find the content when installing package. However, here we are only installing the dependencies, so this will give an error when we run it. Thus, we remove it from the file

The `-e file:.` line in the requirements file indicates that the current directory is a package. I fixed the aforementioned error by removing this line using `sed`, as we are really only interested in installing the dependencies.

Perhaps it would be better to structure the Dockerfile differently, but I think this is the semantically best solution since we are not interested in installing a package.

For context, I'm using this to run a FastAPI application. The full Dockerfile is as follows:

```Dockerfile
FROM python:slim

# git is needed for database
RUN apt-get update && apt-get install -y git

# Set up the working directory and dependencies
WORKDIR /app
COPY requirements.lock ./
RUN sed -i 's/-e file:\.//g' requirements.lock
RUN PYTHONDONTWRITEBYTECODE=1 pip install --no-cache-dir -r requirements.lock

# Copy the source code into the container
# and update the working directory
COPY src/ .
WORKDIR /app/dear_diary

# Run the FastAPI server on port 80 when Docker container starts
CMD ["fastapi", "run", "main.py", "--port", "80"]
```

Let me know whether this indeed is a valid fix, or whether I am doing something wrong! 😄 
