### PR TITLE
Fix compatibile toolchain

### DIFF
--- a/rye/src/bootstrap.rs
+++ b/rye/src/bootstrap.rs
@@ -282,7 +282,7 @@ pub fn get_pip_module(venv: &Path) -> Result<PathBuf, Error> {
     Ok(rv)
 }
 
-/// we only support cpython 3.9 to 3.12
+/// we only support cpython 3.9 to 3.13
 pub fn is_self_compatible_toolchain(version: &PythonVersion) -> bool {
     version.name == "cpython" && version.major == 3 && version.minor >= 9 && version.minor <= 13
 }

--- a/rye/src/bootstrap.rs
+++ b/rye/src/bootstrap.rs
@@ -284,7 +284,7 @@ pub fn get_pip_module(venv: &Path) -> Result<PathBuf, Error> {
 
 /// we only support cpython 3.9 to 3.12
 pub fn is_self_compatible_toolchain(version: &PythonVersion) -> bool {
-    version.name == "cpython" && version.major == 3 && version.minor >= 9 && version.minor <= 12
+    version.name == "cpython" && version.major == 3 && version.minor >= 9 && version.minor <= 13
 }
 
 /// Ensure that the toolchain for the self environment is available.


### PR DESCRIPTION
Resolves: #1426

This pull request includes an update to the compatibility range for the supported Python versions in the `is_self_compatible_toolchain` function.

* [`rye/src/bootstrap.rs`](diffhunk://#diff-5e3b4dd9c9d72709e7551b50ad0bb8933e251e3f7ea71370a13637900c1b349cL285-R287): Updated the supported Python versions to include cpython 3.13.