### PR TITLE
Update Dockerfile example, need to COPY README.md and pyproject.toml

### DIFF
--- a/docs/guide/docker.md
+++ b/docs/guide/docker.md
@@ -22,7 +22,7 @@ This guide requires some familiarity with Docker and Dockerfiles.
     RUN pip install uv
 
     WORKDIR /app
-    COPY requirements.lock ./
+    COPY README.md pyproject.toml requirements.lock ./
     RUN uv pip install --no-cache --system -r requirements.lock
     
     COPY src .


### PR DESCRIPTION
Going back to the Dockerfile example, I saw that `uv pip install ...` required a pyproject.toml and README.md file (generated by `rye init`). You therefore need to copy them into the Dockerfile (which is not specified).

When i don't copy pyproject.toml
![pyproject](https://github.com/user-attachments/assets/7632bd97-99cd-4176-931a-846c3fcdd668)

When i don't copy README.md
![image](https://github.com/user-attachments/assets/ab20775c-b29d-476c-a11e-890cf8fbe950)

