### PR TITLE
Upgrade runners to `macos-14`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,12 +97,12 @@ jobs:
           target: aarch64-unknown-linux-musl
           name: aarch64-linux
         - build: macos
-          os: macos-12
+          os: macos-14
           rust: stable
           target: x86_64-apple-darwin
           name: x86_64-macos
         - build: macos-arm
-          os: macos-12
+          os: macos-14
           rust: stable
           target: aarch64-apple-darwin
           name: aarch64-macos


### PR DESCRIPTION
## Summary

The `macos-12` runners are deprecated: https://github.com/astral-sh/rye/actions/runs/12244443745