### PR TITLE
Fix test_get_download_url

### DIFF
--- a/rye/src/sources/py.rs
+++ b/rye/src/sources/py.rs
@@ -348,5 +348,5 @@ pub fn iter_downloadable<'s>(
 #[test]
 fn test_get_download_url() {
     let url = get_download_url(&"cpython-aarch64-macos@3.8.14".parse().unwrap());
-    assert_eq!(url, Some((PythonVersion { name: "cpython".into(), arch: "aarch64".into(), os: "macos".into(), major: 3, minor: 8, patch: 14, suffix: None }, "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst", Some("d17a3fcc161345efa2ec0b4ab9c9ed6c139d29128f2e34bb636338a484aa7b72"))));
+    assert_eq!(url, Some((PythonVersion { name: "cpython".into(), arch: "aarch64".into(), os: "macos".into(), major: 3, minor: 8, patch: 14, suffix: None }, "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst", Some("d17a3fcc161345efa2ec0b4ab9c9ed6c139d29128f2e34bb636338a484aa7b72"))));
 }


### PR DESCRIPTION
python-build-standalone repo has changed owner

Fixes:
```text
failures:

---- sources::py::test_get_download_url stdout ----
thread 'sources::py::test_get_download_url' panicked at rye/src/sources/py.rs:351:5:
assertion `left == right` failed
  left: Some((PythonVersion { name: "cpython", arch: "aarch64", os: "macos", major: 3, minor: 8, patch: 14, suffix: None }, "https://github.com/astral-sh/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst", Some("d17a3fcc161345efa2ec0b4ab9c9ed6c139d29128f2e34bb636338a484aa7b72")))
 right: Some((PythonVersion { name: "cpython", arch: "aarch64", os: "macos", major: 3, minor: 8, patch: 14, suffix: None }, "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst", Some("d17a3fcc161345efa2ec0b4ab9c9ed6c139d29128f2e34bb636338a484aa7b72")))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    sources::py::test_get_download_url

test result: FAILED. 24 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.52s
```