### PR TITLE
Bump bundled Ruff version to 0.9.6

### DIFF
--- a/rye/src/bootstrap.rs
+++ b/rye/src/bootstrap.rs
@@ -32,7 +32,7 @@ pub const SELF_PYTHON_TARGET_VERSION: PythonVersionRequest = PythonVersionReques
     suffix: None,
 };
 
-const SELF_VERSION: u64 = 26;
+const SELF_VERSION: u64 = 27;
 
 pub const SELF_REQUIREMENTS: &str = r#"
 build==1.2.1
@@ -51,7 +51,7 @@ twine==5.1.1
 unearth==0.14.0
 urllib3==2.0.7
 virtualenv==20.25.0
-ruff==0.8.2
+ruff==0.9.6
 "#;
 
 static FORCED_TO_UPDATE: AtomicBool = AtomicBool::new(false);

--- a/rye/tests/test_ruff.rs
+++ b/rye/tests/test_ruff.rs
@@ -31,7 +31,7 @@ def hello():
       |
     1 | import os
       |        ^^ F401
-    2 | 
+    2 |
     3 | def hello():
       |
       = help: Remove unused import: `os`


### PR DESCRIPTION
CI checks fail for an unrelated reason, see #1458