### PR TITLE
Set Rust toolchain in `rust-toolchain.toml`

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -12,10 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-          components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
+      - name: "Install Rust toolchain"
+        run: rustup component add clippy
       - name: Run clippy
         run: make lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
       - uses: Swatinem/rust-cache@v2
+      - name: "Install Rust toolchain"
+        run: rustup show
       - name: Install cargo insta
         uses: taiki-e/install-action@v2
         with:
@@ -32,10 +31,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
       - uses: Swatinem/rust-cache@v2
+      - name: "Install Rust toolchain"
+        run: rustup show
       - name: Install cargo insta
         uses: taiki-e/install-action@v2
         with:
@@ -51,10 +49,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
       - uses: Swatinem/rust-cache@v2
+      - name: "Install Rust toolchain"
+        run: rustup show
       - name: Install cargo insta
         uses: taiki-e/install-action@v2
         with:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.85"


### PR DESCRIPTION
## Summary

Use a consistent Rust version so tests and lint errors, etc., don't start failing sporadically with each release.