### PR TITLE
find_downloads: set per_page=1 to avoid 504 Timeout

### DIFF
--- a/rye-devtools/src/rye_devtools/find_downloads.py
+++ b/rye-devtools/src/rye_devtools/find_downloads.py
@@ -113,13 +113,15 @@ class CPythonFinder(Finder):
         await self.fetch_indygreg_checksums(downloads, n=20)
         return downloads
 
-    async def fetch_indygreg_downloads(self, pages: int = 100) -> list[PythonDownload]:
+    async def fetch_indygreg_downloads(self, pages: int = 3000) -> list[PythonDownload]:
         """Fetch all the indygreg downloads from the release API."""
         results: dict[Version, dict[tuple[str, str], list[PythonDownload]]] = {}
 
         for page in range(1, pages):
             log(f"Fetching indygreg release page {page}")
-            resp = await fetch(self.client, "%s?page=%d" % (self.RELEASE_URL, page))
+            resp = await fetch(
+                self.client, "%s?per_page=1&page=%d" % (self.RELEASE_URL, page)
+            )
             rows = resp.json()
             if not rows:
                 break


### PR DESCRIPTION
Fetching https://api.github.com/repos/astral-sh/python-build-standalone/releases?page=1 which has a default per_page of 30 will get a 504 Timeout currently.