### PR TITLE
Retire Rye and add a uv migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@
 
 > [!NOTE]
 >
-> If you're getting started with Rye, consider [uv](https://github.com/astral-sh/uv), the
-> [successor project](https://lucumr.pocoo.org/2024/2/15/rye-grows-with-uv/) from the same maintainers.
-> 
-> While Rye is actively maintained, uv offers a more stable and feature-complete experience, and is the recommended
-> choice for new projects.
-> 
-> Having trouble migrating? [Let us know what's missing.](https://github.com/astral-sh/rye/discussions/1342)
+> Rye is no longer developed. We encourage all users to use [uv](https://docs.astral.sh/uv/), the
+> [successor project](https://lucumr.pocoo.org/2024/8/21/harvest-season/) from the same
+> maintainers, which is actively maintained and much more widely used.
+>
+> For current Rye users, please see the [uv migration guide](https://rye.astral.sh/guide/uv/).
+> While Rye will continue to be available, no further updates are planned,
+> including security updates.
 
 Rye is a comprehensive project and package management solution for Python.
 Born from [its creator's](https://github.com/mitsuhiko) desire to establish a

--- a/docs/.overrides/main.html
+++ b/docs/.overrides/main.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}
 
+{% block announce %}
+Rye is no longer developed as of February 2025. Please see the <a href="{{ '/guide/uv/' | url }}">guide on migrating to uv</a>.
+{% endblock %}
+
 {% block hero %}
 <script>
   (function() {

--- a/docs/.overrides/main.html
+++ b/docs/.overrides/main.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block announce %}
-Rye is no longer developed as of February 2025. Please see the <a href="{{ '/guide/uv/' | url }}">guide on migrating to uv</a>.
+Rye is no longer developed as of February 2025. Please see the <a href="{{ 'guide/uv/' | url }}">guide on migrating to uv</a>.
 {% endblock %}
 
 {% block hero %}

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,3 +1,15 @@
+!!! note
+
+    Rye is no longer developed as of February 2025. We encourage all users to use
+    [uv](https://docs.astral.sh/uv/), the [successor project](https://lucumr.pocoo.org/2024/8/21/harvest-season/)
+    from the same maintainers, which is actively maintained and much more widely used.
+
+    For new users, please [install uv](https://docs.astral.sh/uv/getting-started/installation/) instead.
+
+    For current Rye users, please see the [uv migration guide](uv.md). While these installation
+    instructions will continue to work for the foreseeable future, no further updates are planned,
+    including security updates.
+
 # Installation
 
 Rye is built in Rust.  It can either be manually compiled and installed or it can

--- a/docs/guide/uv.md
+++ b/docs/guide/uv.md
@@ -4,7 +4,7 @@ Rye is no longer developed. We recommend that Rye users migrate to [uv](https://
 
 Rye and uv have similar philosophies, CLIs, and user experience. Both are project management tools that follow Python standards wherever possible, so migrating your workflows should be easy. Start with [uv's getting started guide](https://docs.astral.sh/uv/getting-started/).
 
-This document has guidance on how to migrate specific Rye features to uv, targeted at uv 0.8.0 / July 2025. If you're on an older version of uv, please upgrade. (If you are reading this page in the future, check the linked issues below to see if even more features have been implemented in uv!)
+This document has guidance on how to migrate specific Rye features to uv, targeted at uv 0.8 / July 2025. If you're on an older version of uv, please upgrade. (If you are reading this page in the future, check the linked issues below to see if even more features have been implemented in uv!)
 
 ## Migrating existing projects
 
@@ -15,7 +15,7 @@ If you have `[tool.rye]` sections in your `pyproject.toml` file, you will need t
 A few configuration keys are slightly different but easy to migrate:
 
 * `tool.rye.universal` and `tool.rye.generate-hashes` are under the `tool.uv.pip` namespace, i.e., `tool.uv.pip.universal` and `tool.uv.pip.generate-hashes`.
-* `tool.rye.lock-with-sources` corresponds to `tool.uv.no-sources` but with the sense inverted, i.e., convert `lock-with-sources = false` to `no-sources = true`.
+* `tool.rye.lock-with-sources` corresponds to `tool.uv.no-sources` but the Boolean value of the setting is inverted, i.e., convert `lock-with-sources = false` to `no-sources = true`.
 * `tool.rye.virtual` corresponds to `tool.uv.package` but with the sense inverted, i.e., convert `virtual = true` to `package = false`.
 * `tool.rye.sources` loosely corresponds to `tool.uv.indexes`. See below for syntax differences.
 * `tool.rye.dev-dependencies` should be converted to the standardized [`dependency-groups.dev`](https://docs.astral.sh/uv/concepts/projects/dependencies/#dependency-groups) key (`tool.uv.dev-dependencies` works too but is deprecated).
@@ -52,7 +52,7 @@ Both uv and Rye support installing the same managed Python releases from [python
 
 Rye supports a [global Python shim](https://rye.astral.sh/guide/shims/) that sets up the `python` and `python3` commands to run a managed version of Python. While this is highly convenient, it does risk breaking existing software on your computer that expects the OS version of Python.
 
-As of uv 0.8.0, `uv python install` will install a `python3.x` command for the latest stable managed Python. If you would like to install `python` and `python3` commands too. you can use `uv python install --preview`. Note that this is _not_ a shim, just a direct link to the Python installation; it does not pick up dependencies from the current project. This behavior may change in the future; [astral-sh/uv#6265](https://github.com/astral-sh/uv/issues/6265) tracks uv adding a Python shim.
+As of uv 0.8.0, `uv python install` will install a `python3.x` command for the latest stable managed Python. If you would like to install `python` and `python3` commands too. you can use `uv python install --default`. Note that this is _not_ a shim, just a direct link to the Python installation; it does not pick up dependencies from the current project. This behavior may change in the future; [astral-sh/uv#6265](https://github.com/astral-sh/uv/issues/6265) tracks uv adding a Python shim.
 
 In general, you can use `uv run python` to get a Python shell in the current project, and `uvx python` to get an isolated Python. Both commands support `--with` to add dependencies. See the documentation for [`uv run`](https://docs.astral.sh/uv/reference/cli/#uv-run).
 

--- a/docs/guide/uv.md
+++ b/docs/guide/uv.md
@@ -56,11 +56,11 @@ As of uv 0.8.0, `uv python install` will install a `python3.x` command for the l
 
 In general, you can use `uv run python` to get a Python shell in the current project, and `uvx python` to get an isolated Python. Both commands support `--with` to add dependencies. See the documentation for [`uv run`](https://docs.astral.sh/uv/reference/cli/#uv-run).
 
-### `rye fmt` and `rye test`
+### `rye lint`, `rye fmt`, and `rye test`
 
-Rye has short commands `rye fmt` and `rye test` that run [Ruff](https://docs.astral.sh/ruff/) and [pytest](https://docs.pytest.org/en/stable/), respectively. uv currently does not have specific aliases for these. (See also the section above about scripts and tasks.)
+Rye has short commands that run other programs. `rye lint` (aka `rye check`) and `rye fmt` (aka `rye format`) both run [Ruff](https://docs.astral.sh/ruff/), and `rye test` runs [pytest](https://docs.pytest.org/en/stable/). uv currently does not have specific aliases for these. (See also the section above about scripts and tasks.)
 
-You can add these to your projects as dev dependencies with `uv add --dev ruff` and `uv add --dev pytest`, which will let you run `uv run ruff format` and `uv run pytest`. The versions of Ruff and pytest will be tracked in your `pyproject.toml` for reproducibility.
+You can add these to your projects as dev dependencies with `uv add --dev ruff` and `uv add --dev pytest`, which will let you run `uv run ruff check`, `uv run ruff format`, and `uv run pytest`. The versions of Ruff and pytest will be tracked in your `pyproject.toml` for reproducibility.
 
 Alternatively, you can use `uvx ruff` to run it without installing it to your project. (This will not work for pytest, which needs to run your project's code; you need to add it as a dev dependency, just as `rye test` requires.)
 

--- a/docs/guide/uv.md
+++ b/docs/guide/uv.md
@@ -1,0 +1,83 @@
+# Migrating to uv
+
+Rye is no longer developed. We recommend that Rye users migrate to [uv](https://docs.astral.sh/uv/), the [successor project](https://lucumr.pocoo.org/2024/8/21/harvest-season/) from the same maintainers. uv is actively maintained and much more widely used, and it supports almost all of Rye's features (as well as several features not available in Rye).
+
+Rye and uv have similar philosophies, CLIs, and user experience. Both are project management tools that follow Python standards wherever possible, so migrating your workflows should be easy. Start with [uv's getting started guide](https://docs.astral.sh/uv/getting-started/).
+
+This document has guidance on how to migrate specific Rye features to uv, targeted at uv 0.8.0 / July 2025. If you're on an older version of uv, please upgrade. (If you are reading this page in the future, check the linked issues below to see if even more features have been implemented in uv!)
+
+## Migrating existing projects
+
+If you don't have `[tool.rye]` sections in your `pyproject.toml` file, your project should work out of the box in uv with no further changes.
+
+If you have `[tool.rye]` sections in your `pyproject.toml` file, you will need to convert them to `[tool.uv]` sections. Most of the time, all you need to do is rename the sections.
+
+A few configuration keys are slightly different but easy to migrate:
+
+* `tool.rye.universal` and `tool.rye.generate-hashes` are under the `tool.uv.pip` namespace, i.e., `tool.uv.pip.universal` and `tool.uv.pip.generate-hashes`.
+* `tool.rye.lock-with-sources` corresponds to `tool.uv.no-sources` but with the sense inverted, i.e., convert `lock-with-sources = false` to `no-sources = true`.
+* `tool.rye.virtual` corresponds to `tool.uv.package` but with the sense inverted, i.e., convert `virtual = true` to `package = false`.
+* `tool.rye.sources` loosely corresponds to `tool.uv.indexes`. See below for syntax differences.
+* `tool.rye.dev-dependencies` should be converted to the standardized [`dependency-groups.dev`](https://docs.astral.sh/uv/concepts/projects/dependencies/#dependency-groups) key (`tool.uv.dev-dependencies` works too but is deprecated).
+
+See also the [uv configuration reference](https://docs.astral.sh/uv/reference/settings/).
+
+### Scripts and tasks: `[tool.rye.scripts]`
+
+As of July 2025, uv does not yet have a task runner. Please see the feature request in [astral-sh/uv#5903](https://github.com/astral-sh/uv/issues/5903), which also has links to some third-party alternatives that are usable today via `uv run`.
+
+(Note that this is not related to executable scripts in the standard `[project.scripts]` section, which is fully supported in uv.)
+
+### Indexes and repos: `[[tool.rye.sources]]`
+
+uv's support for configuring package indexes is, in general, more flexible than Rye's. Indexes are listed in `[[tool.uv.indexes]]` (which corresponds to `[[tool.rye.sources]]`), and you can specify that you want specific packages in your requirements to come from a particular index using `[[tool.uv.sources]]`. To override the default index, use `default = true` instead of `name = "default"`. For a "find-links" index, use `format = "flat"` instead of `type = "find-links"`.
+
+See the [uv documentation on package indexes](https://docs.astral.sh/uv/concepts/indexes/) for more details.
+
+Rye expands environment variables in the URLs of indexes. uv currently does not support this exact feature (see [astral-sh/uv#5734](https://github.com/astral-sh/uv/issues/5734)), but for most use cases there are alternatives:
+
+* If you are filling in a username and password, [uv supports](https://docs.astral.sh/uv/concepts/indexes/#authentication) setting them via environment variables or loading them from an external keyring provider.
+* If you are filling in the actual URL of an index, you can instead specify the full URL of an index on the command line with the [`UV_INDEX`](https://docs.astral.sh/uv/reference/environment/#uv_index) or [`UV_DEFAULT_INDEX`](https://docs.astral.sh/uv/reference/environment/#uv_default_index) environment variables.
+* If you are using custom indexes for PyTorch, consider the [`torch-backend = auto`](https://docs.astral.sh/uv/reference/settings/#pip_torch-backend) setting.
+
+You can also configure indexes in [global configuration](https://docs.astral.sh/uv/concepts/configuration-files/) to avoid placing them in your project-specific `pyproject.toml` file.
+
+## Migrating command-line usage and workflows
+
+While you will likely find the `uv` CLI tool familiar if you're used to `rye`, they have their own interfaces. Please read the [getting started guide](https://docs.astral.sh/uv/getting-started/features/) and the [`uv` CLI reference](https://docs.astral.sh/uv/reference/cli/).
+
+### Python installations and shims
+
+Both uv and Rye support installing the same managed Python releases from [python-build-standalone](https://github.com/astral-sh/python-build-standalone) (now under Astral stewardship), so you should find Python behavior to be highly compatible.
+
+Rye supports a [global Python shim](https://rye.astral.sh/guide/shims/) that sets up the `python` and `python3` commands to run a managed version of Python. While this is highly convenient, it does risk breaking existing software on your computer that expects the OS version of Python.
+
+As of uv 0.8.0, `uv python install` will install a `python3.x` command for the latest stable managed Python. If you would like to install `python` and `python3` commands too. you can use `uv python install --preview`. Note that this is _not_ a shim, just a direct link to the Python installation; it does not pick up dependencies from the current project. This behavior may change in the future; [astral-sh/uv#6265](https://github.com/astral-sh/uv/issues/6265) tracks uv adding a Python shim.
+
+In general, you can use `uv run python` to get a Python shell in the current project, and `uvx python` to get an isolated Python. Both commands support `--with` to add dependencies. See the documentation for [`uv run`](https://docs.astral.sh/uv/reference/cli/#uv-run).
+
+### `rye fmt` and `rye test`
+
+Rye has short commands `rye fmt` and `rye test` that run [Ruff](https://docs.astral.sh/ruff/) and [pytest](https://docs.pytest.org/en/stable/), respectively. uv currently does not have specific aliases for these. (See also the section above about scripts and tasks.)
+
+You can add these to your projects as dev dependencies with `uv add --dev ruff` and `uv add --dev pytest`, which will let you run `uv run ruff format` and `uv run pytest`. The versions of Ruff and pytest will be tracked in your `pyproject.toml` for reproducibility.
+
+Alternatively, you can use `uvx ruff` to run it without installing it to your project. (This will not work for pytest, which needs to run your project's code; you need to add it as a dev dependency, just as `rye test` requires.)
+
+### Project creation
+
+`rye init --script` creates a project with a script runnable with `uv run`. The corresponding uv command is `uv init --package`, which adds an executable script by default. `uv init --script` does something else: it creates a [single-file executable script that supports dependencies](https://docs.astral.sh/uv/guides/scripts/) with a PEP 723 header, a feature Rye does not support.
+
+### Lockfiles, Docker
+
+Rye generates a lockfile named `requirements.lock` with a syntax compatible with `pip` and other tools that handle `requirements.txt` files.
+
+uv uses its own lock file format (`uv.lock`). If you need a `requirements.txt`-style lock file for use with other tools, you can generate one with [`uv export`](https://docs.astral.sh/uv/concepts/projects/sync/#exporting-the-lockfile).
+
+However, we strongly recommend using uv to manage your environment installation in production, too! In particular, Rye's Docker documentation suggests using `uv pip install` or `pip install` to install from the `requirements.lock` file. Instead of trying to adapt this workflow, take a look at [uv's Docker integration guide](https://docs.astral.sh/uv/guides/integration/docker/), which recommends using uv directly in your Docker image, with `uv sync` in your build step and `uv run` in your `CMD`.
+
+## Feedback
+
+If you have issues migrating a Rye project to uv, please feel free to [ask for help in one of uv's support forums](https://docs.astral.sh/uv/getting-started/help/) such as GitHub or Discord.
+
+Thank you for using Rye! We hope you enjoy uv.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,13 +10,12 @@ hide:
 
 !!! note
 
-    If you're getting started with Rye, consider [uv](https://github.com/astral-sh/uv), the
-    [successor project](https://lucumr.pocoo.org/2024/2/15/rye-grows-with-uv/) from the same maintainers.
+    Rye is no longer developed. We encourage all users to use [uv](https://docs.astral.sh/uv/), the
+    [successor project](https://lucumr.pocoo.org/2024/8/21/harvest-season/) from the same
+    maintainers, which is actively maintained and much more widely used.
 
-    While Rye is actively maintained, uv offers a more stable and feature-complete experience, and is the recommended
-    choice for new projects.
-
-    Having trouble migrating? [Let us know what's missing.](https://github.com/astral-sh/rye/discussions/1342)
+    For current Rye users, please see the [uv migration guide](./guide/uv.md). While Rye will
+    continue to be available, no further updates are planned, including security updates.
 
 Rye is a comprehensive project and package management solution for Python.
 Born from [its creator's](https://github.com/mitsuhiko) desire to establish a
@@ -30,13 +29,5 @@ A hassle-free experience for Python developers at every level.
 <script async defer src="https://buttons.github.io/buttons.js"></script>
 <p align="center">
   <a class="github-button" href="https://github.com/astral-sh/rye" data-size="large" data-show-count="true" data-color-scheme="light" aria-label="Star astral-sh/rye on GitHub">Star</a>
-<a class="github-button" href="https://github.com/astral-sh/rye/discussions" data-icon="octicon-comment-discussion" data-size="large" aria-label="Discuss astral-sh/rye on GitHub">Discuss</a>
   <a class="github-button" href="https://github.com/sponsors/mitsuhiko" data-size="large" data-icon="octicon-heart" data-color-scheme="light" aria-label="Sponsor @mitsuhiko on GitHub">Sponsor</a>
 </p>
-
-!!! abstract "Installation Instructions"
-
-    {% include-markdown ".includes/quick-install.md" %}
-
-    For the next steps or ways to customize the installation, head over to the detailed
-    [installation](./guide/installation.md) guide.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,3 +1,5 @@
+# You can preview docs with `rye run serve-docs` or `uv run mkdocs serve`.
+
 site_name: Rye
 site_description: An Experimental Package Management Solution for Python
 repo_name: astral-sh/rye
@@ -8,6 +10,7 @@ copyright: Copyright &copy; 2023 Armin Ronacher
 nav:
   - Welcome: index.md
   - User Guide:
+    - Migrating to uv: guide/uv.md
     - guide/index.md
     - Installation: guide/installation.md
     - Basics: guide/basics.md


### PR DESCRIPTION
https://lucumr.pocoo.org/2024/8/21/harvest-season/

> Domination is a goal because it means that most investment will go
> into one stack. I can only re-iterate my wish and desire that Rye (and
> with it a lot of other tools in the space) should cease to exist once
> the dominating tool has been established. For me uv is poised to be
> that tool. It's not quite there today yet for all cases, but it will
> be in no time, and now is the moment to step up as a community and
> start to start to rally around it. That doesn't mean that this tool
> will be the tool forever. Things come and go and maybe there is a
> future for some other tool.
>
> But today I'm looking forward to the moment when there will be a final
> release of Rye that is no remaining functionality other than to just
> largely alias to uv, that retires Rye specific functionality and
> migrates you over to uv.

This does not do a final release - adding a compatibility layer for uv and an automatic migration is likely to be buggy and incomplete, and users are better served by changing the command they type to `uv`. Instead, it adds a migration guide based on the discussion thread (https://github.com/astral-sh/rye/discussions/1342), documenting things that are not immediately obvious to a user swapping out `rye` for `uv`.